### PR TITLE
Fix CI build parity and macOS deployment target

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -23,8 +23,6 @@ jobs:
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.3.1
-        env:
-          CIBW_BUILD: ${{ github.event_name == 'release' && 'cp310-* cp311-* cp312-* cp313-* cp314-*' || 'cp314-*' }}
 
       - uses: actions/upload-artifact@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ test-command = "python -c \"import gropt; gropt.demo()\""
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]
+environment = {MACOSX_DEPLOYMENT_TARGET = "10.13"}
 
 [tool.pixi.workspace]
 channels = ["conda-forge"]


### PR DESCRIPTION
## Summary

- Remove conditional `CIBW_BUILD` env override so all Python versions (cp310–cp314) are always built on every PR/push, not just on releases. This ensures issues like the cp310 macOS deployment target error surface before a release.
- Set `MACOSX_DEPLOYMENT_TARGET = "10.13"` in `[tool.cibuildwheel.macos]` to satisfy nanobind's `std::align_val_t` requirement (aligned deallocation requires macOS 10.13+; cibuildwheel defaulted cp310 x86_64 to 10.9).

## Test plan

- [ ] Verify CI builds all Python versions (cp310–cp314) on this PR
- [ ] Verify macOS x86_64 cp310 wheel builds successfully without deployment target errors