### PR TITLE
Fix version drift caused by dirty git state during cibuildwheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ build-backend = "scikit_build_core.build"
 provider = "scikit_build_core.metadata.setuptools_scm"
 
 [tool.setuptools_scm]
+local_scheme = "no-local-version"
 
 [tool.cibuildwheel]
 build = "cp310-* cp311-* cp312-* cp313-* cp314-*"


### PR DESCRIPTION
## Summary

- `nanobind_add_stub` writes `gropt/gropt_wrapper.pyi` into the source tree as part of the cp310 build
- This makes git dirty for all subsequent Python version builds in the same cibuildwheel run
- setuptools-scm sees a dirty repo and appends a local version identifier (e.g. `+d20260301`), causing cp311+ wheels to have a different version than cp310
- PyPI rejects or mishandles packages with local version identifiers

Fix: add `local_scheme = "no-local-version"` to `[tool.setuptools_scm]` so the dirty suffix is never appended.

## Test plan

- [ ] Verify all Python versions (cp310–cp314) produce the same version string in CI