### PR TITLE
Fix version drift: pin version from release tag before cibuildwheel

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -21,6 +21,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set version from release tag
+        if: github.event_name == 'release'
+        run: echo "SETUPTOOLS_SCM_PRETEND_VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
+
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.3.1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ local_scheme = "no-local-version"
 build = "cp310-* cp311-* cp312-* cp313-* cp314-*"
 skip = "*-musllinux_* *-manylinux_i686 *-win32 pp*"
 test-command = "python -c \"import gropt; gropt.demo()\""
+environment-pass = ["SETUPTOOLS_SCM_PRETEND_VERSION"]
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]


### PR DESCRIPTION
## Summary

- On release builds, `nanobind_add_stub` writes `gropt_wrapper.pyi` into the source tree during the cp310 build, making git dirty for all subsequent Python version builds
- setuptools-scm sees a dirty repo at the release tag and bumps past it (e.g. `v2.0.0rc5` → `2.0.0rc6.dev0`)
- Fix: capture `SETUPTOOLS_SCM_PRETEND_VERSION` from `GITHUB_REF_NAME` before cibuildwheel runs, and pass it through to all build environments via `environment-pass`
- Non-release builds (PR/push) are unaffected — they still get normal git-derived versions

## Test plan

- [ ] Merge and tag `v2.0.0rc7`, verify all wheels on PyPI carry version `2.0.0rc7`