### PR TITLE
Fix version step: shell: bash for Windows + log version

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -23,7 +23,11 @@ jobs:
 
       - name: Set version from release tag
         if: github.event_name == 'release'
-        run: echo "SETUPTOOLS_SCM_PRETEND_VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
+        shell: bash
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "Setting version: $VERSION"
+          echo "SETUPTOOLS_SCM_PRETEND_VERSION=$VERSION" >> $GITHUB_ENV
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.3.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ local_scheme = "no-local-version"
 
 [tool.cibuildwheel]
 build = "cp310-* cp311-* cp312-* cp313-* cp314-*"
-skip = "*-musllinux_* *-manylinux_i686 *-win32 pp*"
+skip = "*-musllinux_* *-manylinux_i686 *-win32"
 test-command = "python -c \"import gropt; gropt.demo()\""
 environment-pass = ["SETUPTOOLS_SCM_PRETEND_VERSION"]
 


### PR DESCRIPTION
## Summary
- Add `shell: bash` to the "Set version from release tag" step so it works on Windows runners (which default to PowerShell)
- Echo the resolved version to stdout so it's visible in the Actions log

## Root cause
The `${GITHUB_REF_NAME#v}` bash parameter expansion silently fails on Windows because the default shell is PowerShell, leaving `SETUPTOOLS_SCM_PRETEND_VERSION` unset. Mac/Linux already use bash by default, which is why only Windows wheels had the wrong version.