### PR TITLE
Optimization improvements and legacy cleanup

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -18,16 +18,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Set version from release tag
-        if: github.event_name == 'release'
-        shell: bash
-        run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          echo "Setting version: $VERSION"
-          echo "SETUPTOOLS_SCM_PRETEND_VERSION=$VERSION" >> $GITHUB_ENV
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.3.1
@@ -43,8 +33,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - uses: actions/setup-python@v5
         with:
@@ -66,15 +54,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
 
       - name: Install build dependencies
-        run: pip install scikit-build-core nanobind setuptools-scm
+        run: pip install scikit-build-core nanobind
 
       - name: Install gropt with Eigen assertions enabled
         run: pip install --no-build-isolation -e . -C cmake.define.GROPT_EIGEN_ASSERTIONS=ON
@@ -82,9 +68,26 @@ jobs:
       - name: Smoke test
         run: python -c "import gropt; gropt.demo()"
 
+  check_version:
+    name: Check version matches tag
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify version matches tag
+        shell: bash
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
+          echo "Tag: $TAG  |  pyproject.toml: $VERSION"
+          if [ "$TAG" != "$VERSION" ]; then
+            echo "ERROR: tag v$TAG does not match pyproject.toml version $VERSION — did you forget to bump the version?"
+            exit 1
+          fi
+
   publish:
     name: Publish to PyPI
-    needs: [build_wheels, build_sdist, test]
+    needs: [build_wheels, build_sdist, test, check_version]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'created'
     environment:

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ private*
 build-release/
 build-debug/
 stubs/
+.scikit-build/
 
 # We might eventualyl need these for tests
 *.h5

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ set(GROPT_SOURCES
     ${GROPT_SRC_DIR}/ils_bicgstabl.cpp
     ${GROPT_SRC_DIR}/op_main.cpp
     ${GROPT_SRC_DIR}/op_bvalue.cpp
+    ${GROPT_SRC_DIR}/op_concomitant.cpp
     ${GROPT_SRC_DIR}/op_gradient.cpp
     ${GROPT_SRC_DIR}/op_identity.cpp
     ${GROPT_SRC_DIR}/op_moment.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,28 +36,28 @@ set(GROPT_SOURCES
     ${GROPT_SRC_DIR}/workspace_solver.cpp
 )
 
-nanobind_add_module(gropt_wrapper
-    gropt/gropt_wrapper/gropt_wrapper.cpp
-    ${GROPT_SOURCES}
-)
-
-target_include_directories(gropt_wrapper PRIVATE
+add_library(gropt_core STATIC ${GROPT_SOURCES})
+target_include_directories(gropt_core PUBLIC
     ${GROPT_SRC_DIR}
     ${GROPT_SRC_DIR}/external
 )
+target_compile_definitions(gropt_core PUBLIC FMT_UNICODE=0)
 
-target_compile_definitions(gropt_wrapper PRIVATE FMT_UNICODE=0)
+nanobind_add_module(gropt_wrapper
+    gropt/gropt_wrapper/gropt_wrapper.cpp
+)
+target_link_libraries(gropt_wrapper PRIVATE gropt_core)
 
 # Eigen assertion control: ON = keep assertions + NaN-init for testing,
 #                          OFF = disable assertions for distribution wheels
 option(GROPT_EIGEN_ASSERTIONS "Enable Eigen runtime assertions (for testing)" OFF)
 if(GROPT_EIGEN_ASSERTIONS)
-    target_compile_options(gropt_wrapper PRIVATE
+    target_compile_options(gropt_core PRIVATE
         $<IF:$<CXX_COMPILER_ID:MSVC>,/UNDEBUG,-UNDEBUG>
     )
-    target_compile_definitions(gropt_wrapper PRIVATE EIGEN_INITIALIZE_MATRICES_BY_NAN)
+    target_compile_definitions(gropt_core PRIVATE EIGEN_INITIALIZE_MATRICES_BY_NAN)
 else()
-    target_compile_definitions(gropt_wrapper PRIVATE EIGEN_NO_DEBUG)
+    target_compile_definitions(gropt_core PRIVATE EIGEN_NO_DEBUG)
 endif()
 
 install(TARGETS gropt_wrapper LIBRARY DESTINATION gropt)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ set(GROPT_SOURCES
 )
 
 add_library(gropt_core STATIC ${GROPT_SOURCES})
+set_target_properties(gropt_core PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_include_directories(gropt_core PUBLIC
     ${GROPT_SRC_DIR}
     ${GROPT_SRC_DIR}/external

--- a/clean.py
+++ b/clean.py
@@ -1,3 +1,5 @@
+import os
+import os
 import shutil
 from pathlib import Path
 

--- a/clean.py
+++ b/clean.py
@@ -7,10 +7,15 @@ from pathlib import Path
 project_root = Path(__file__).parent.resolve()
 
 # List of directories to remove completely.
+# '.scikit-build' and 'build' contain the CMake cache — only remove for a full rebuild.
 dirs_to_remove = [
+    'dist',
+]
+
+# Removing these forces a full CMake recompile of all C++ files.
+cmake_dirs_to_remove = [
     '.scikit-build',
     'build',
-    'dist',
 ]
 
 # Glob pattern for other directories to remove.
@@ -18,6 +23,8 @@ glob_patterns_to_remove = [
     '*.egg-info',
     '*.so',  # Add this if you want to clean up stray .so files in the root
     '*.pyd',  # Add this if you want to clean up stray .pyd files in the root
+    '**/gropt_wrapper*.pyd',  # Remove all compiled wrapper binaries to ensure only one exists after rebuild
+    '**/gropt_wrapper*.so',
 ]
 
 # Glob patterns for directories searched recursively under the project root.
@@ -29,10 +36,17 @@ recursive_glob_patterns_to_remove = [
 # --- Main Execution ---
 def main():
     """Find and removes build artifacts in the project root."""
-    print('--- Starting cleanup script ---')
+    import sys
+    full = '--full' in sys.argv
+    if full:
+        print('--- Starting FULL cleanup script (CMake cache will be removed) ---')
+    else:
+        print('--- Starting cleanup script ---')
+
+    all_dirs = dirs_to_remove + (cmake_dirs_to_remove if full else [])
 
     # Remove specified directories
-    for dir_name in dirs_to_remove:
+    for dir_name in all_dirs:
         path = project_root / dir_name
         if path.is_dir():
             print(f'Removing directory: {path.relative_to(project_root)}')

--- a/clean.py
+++ b/clean.py
@@ -20,6 +20,11 @@ glob_patterns_to_remove = [
     '*.pyd',  # Add this if you want to clean up stray .pyd files in the root
 ]
 
+# Glob patterns for directories searched recursively under the project root.
+recursive_glob_patterns_to_remove = [
+    'gropt/__pycache__',
+]
+
 
 # --- Main Execution ---
 def main():
@@ -45,6 +50,13 @@ def main():
             elif path.is_file():
                 print(f'Removing glob-matched file: {path.relative_to(project_root)}')
                 path.unlink()
+
+    # Remove specific recursive paths
+    for pattern in recursive_glob_patterns_to_remove:
+        path = project_root / pattern
+        if path.is_dir():
+            print(f'Removing directory: {path.relative_to(project_root)}')
+            shutil.rmtree(path)
 
     print('--- Cleanup finished successfully ---')
 

--- a/examples/diffusion/diffusion_constraint.ipynb
+++ b/examples/diffusion/diffusion_constraint.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "de4eb90d",
    "metadata": {},
    "outputs": [],
@@ -12,7 +12,9 @@
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "\n",
-    "import gropt"
+    "import gropt\n",
+    "\n",
+    "print(gropt.__file__)"
    ]
   },
   {
@@ -21,7 +23,37 @@
    "id": "7ab49004-aa1c-47ff-9eef-57e6ae29a2d4",
    "metadata": {},
    "outputs": [],
-   "source": "gparams = gropt.GroptParams()\ngparams.diff_init()\n\ngparams.add_gmax(.03)\ngparams.add_smax(100)\ngparams.add_moment(0,0.0)\ngparams.add_moment(1,0.0)\ngparams.add_moment(2,0.0)\ngparams.add_bvalue(106,1)\n\nstart_t = timer()\nresult = gropt.solve(gparams, max_iter=5000)\nout = result.X\nstop_t = timer()\n\nprint(f'Converged: {result.converged}   Solve time: {1000*(stop_t-start_t):.1f} ms')\n\nplt.figure(figsize=(6,3))\ntt_ms = np.arange(out.size)*gparams.dt*1e3\nplt.plot(tt_ms, out)\nplt.show()"
+   "source": [
+    "gparams = gropt.GroptParams()\n",
+    "gparams.diff_init()\n",
+    "\n",
+    "gparams.add_gmax(.03)\n",
+    "gparams.add_smax(100)\n",
+    "gparams.add_moment(0,0.0)\n",
+    "gparams.add_moment(1,0.0)\n",
+    "gparams.add_moment(2,0.0)\n",
+    "gparams.add_bvalue(106,1)\n",
+    "\n",
+    "start_t = timer()\n",
+    "result = gropt.solve(gparams, max_iter=5000)\n",
+    "out = result.X\n",
+    "stop_t = timer()\n",
+    "\n",
+    "print(f'Converged: {result.converged}   Solve time: {1000*(stop_t-start_t):.1f} ms')\n",
+    "\n",
+    "plt.figure(figsize=(6,3))\n",
+    "tt_ms = np.arange(out.size)*gparams.dt*1e3\n",
+    "plt.plot(tt_ms, out)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1dfcb878",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -40,7 +72,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.5"
+   "version": "3.13.7"
   }
  },
  "nbformat": 4,

--- a/gropt/__init__.py
+++ b/gropt/__init__.py
@@ -1,4 +1,8 @@
+from importlib.metadata import version
+__version__ = version("gropt")
+
 from .gropt_wrapper import *
+from .gropt_wrapper import __build_date__
 from . import readasc
 from .utils import demo, setup_logging
 

--- a/gropt/gropt_wrapper.pyi
+++ b/gropt/gropt_wrapper.pyi
@@ -6,6 +6,8 @@ import numpy
 from numpy.typing import NDArray
 
 
+__build_date__: str = 'Mar  4 2026 11:50:37'
+
 def set_log_level(level: int) -> None:
     """
     Set the log level for the C++ gropt library.
@@ -319,25 +321,42 @@ class GroptParams:
         operator in all_op and all_obj.
         """
 
-class SolverGroptSDMM:
-    """SDMM solver for GrOpt gradient optimization problems."""
+class Solver:
+    @property
+    def extra_debug(self) -> bool:
+        """
+        If True, populate debug_solver with per-iteration history after solve().
+        """
 
-    def __init__(self) -> None: ...
+    @extra_debug.setter
+    def extra_debug(self, arg: bool, /) -> None: ...
+
+    def get_debug(self) -> dict:
+        """
+        Return debug history as a dict of lists of numpy arrays.
+
+        Only populated when extra_debug=True before solve().
+
+        Returns
+        -------
+        dict with keys: hist_X, hist_Ax, hist_z, hist_y, hist_Aty
+            Each value is a list of 1-D numpy arrays, one per logged iteration.
+        """
 
     def set_general_params(self, min_iter: int = 1, max_iter: int = 2000, log_interval: int = 20, gamma_x: float = 1.6, max_feval: int = 12000) -> None:
         """
         Set general solver parameters.
 
-        Parameters 
+        Parameters
         ----------
         min_iter : int, optional
-            Minimum SDMM iterations.
+            Minimum iterations.
         max_iter : int, optional
-            Maximum SDMM iterations.
+            Maximum iterations.
         log_interval : int, optional
             Logging interval (only visible with verbose logging).
         gamma_x : float, optional
-            Relaxation parameter for SDMM updates.
+            Relaxation parameter for updates.
         max_feval : int, optional
             Maximum total function evaluations.
         """
@@ -351,7 +370,7 @@ class SolverGroptSDMM:
         ils_tol : float, optional
             Relative tolerance for the inner solver.
         ils_max_iter : int, optional
-            Maximum ILS iterations per SDMM iteration.
+            Maximum ILS iterations per outer iteration.
         ils_min_iter : int, optional
             Minimum ILS iterations.
         ils_sigma : float, optional
@@ -359,6 +378,11 @@ class SolverGroptSDMM:
         ils_tik_lam : float, optional
             Tikhonov regularization parameter.
         """
+
+class SolverGroptSDMM(Solver):
+    """SDMM solver for GrOpt gradient optimization problems."""
+
+    def __init__(self) -> None: ...
 
     def set_sdmm_params(self, rw_interval: int = 8, rw_e_corr: float = 0.4, rw_eps: float = 1e-36, rw_scalelim: float = 1.5, grw_min_infeasible: int = 20, grw_interval: int = 20, grw_mod: float = 2.0) -> None:
         """
@@ -397,46 +421,10 @@ class SolverGroptSDMM:
             The optimization result containing the waveform and convergence info.
         """
 
-class SolverOSQP:
+class SolverOSQP(Solver):
     """OSQP solver for GrOpt gradient optimization problems."""
 
     def __init__(self) -> None: ...
-
-    def set_general_params(self, min_iter: int = 1, max_iter: int = 2000, log_interval: int = 20, gamma_x: float = 1.6, max_feval: int = 12000) -> None:
-        """
-        Set general solver parameters.
-
-        Parameters 
-        ----------
-        min_iter : int, optional
-            Minimum OSQP iterations.
-        max_iter : int, optional
-            Maximum OSQP iterations.
-        log_interval : int, optional
-            Logging interval (only visible with verbose logging).
-        gamma_x : float, optional
-            Relaxation parameter for OSQP updates.
-        max_feval : int, optional
-            Maximum total function evaluations.
-        """
-
-    def set_ils_params(self, ils_tol: float = 0.001, ils_max_iter: int = 20, ils_min_iter: int = 2, ils_sigma: float = 0.0001, ils_tik_lam: float = 0.0) -> None:
-        """
-        Set indirect linear solver parameters.
-
-        Parameters
-        ----------
-        ils_tol : float, optional
-            Relative tolerance for the inner solver.
-        ils_max_iter : int, optional
-            Maximum ILS iterations per OSQP iteration.
-        ils_min_iter : int, optional
-            Minimum ILS iterations.
-        ils_sigma : float, optional
-            ADMM penalty parameter.
-        ils_tik_lam : float, optional
-            Tikhonov regularization parameter.
-        """
 
     def solve(self, gparams: GroptParams) -> SolveResult:
         """

--- a/gropt/gropt_wrapper.pyi
+++ b/gropt/gropt_wrapper.pyi
@@ -6,7 +6,7 @@ import numpy
 from numpy.typing import NDArray
 
 
-__build_date__: str = 'Mar 11 2026 20:06:43'
+__build_date__: str = 'Mar 11 2026 21:02:43'
 
 def set_log_level(level: int) -> None:
     """
@@ -368,7 +368,7 @@ class Solver:
             Each value is a list of 1-D numpy arrays, one per logged iteration.
         """
 
-    def set_general_params(self, min_iter: int = 1, max_iter: int = 2000, log_interval: int = 20, gamma_x: float = 1.6, max_feval: int = 12000) -> None:
+    def set_general_params(self, min_iter: int = 1, max_iter: int = 2000, log_interval: int = 20, gamma_x: float = 1.6, max_feval: int = 12000, extra_iters: int = 0) -> None:
         """
         Set general solver parameters.
 
@@ -384,6 +384,8 @@ class Solver:
             Relaxation parameter for updates.
         max_feval : int, optional
             Maximum total function evaluations.
+        extra_iters : int, optional
+            Number of extra iterations to run after solution is found.
         """
 
     def set_ils_params(self, ils_tol: float = 0.001, ils_max_iter: int = 20, ils_min_iter: int = 2, ils_sigma: float = 0.0001, ils_tik_lam: float = 0.0) -> None:
@@ -466,7 +468,7 @@ class SolverOSQP(Solver):
             The optimization result containing the waveform and convergence info.
         """
 
-def solve(params: GroptParams, min_iter: int = 1, max_iter: int = 2000, log_interval: int = 20, gamma_x: float = 1.6, max_feval: int = 12000, ils_tol: float = 0.001, ils_max_iter: int = 20, ils_min_iter: int = 2, ils_sigma: float = 0.0001, ils_tik_lam: float = 0.0) -> SolveResult:
+def solve(params: GroptParams, min_iter: int = 1, max_iter: int = 2000, log_interval: int = 20, gamma_x: float = 1.6, max_feval: int = 12000, extra_iters: int = 0, ils_tol: float = 0.001, ils_max_iter: int = 20, ils_min_iter: int = 2, ils_sigma: float = 0.0001, ils_tik_lam: float = 0.0) -> SolveResult:
     """
     Convenience function to solve a GrOpt problem.
 

--- a/gropt/gropt_wrapper.pyi
+++ b/gropt/gropt_wrapper.pyi
@@ -1,5 +1,3 @@
-"""GrOpt: Gradient Optimization for MRI"""
-
 from collections.abc import Callable
 import enum
 from typing import Annotated, overload
@@ -594,4 +592,17 @@ def get_SAFE(G: Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')
     -------
     np.ndarray
         SAFE response curve.
+    """
+
+def test_eigen_assertions(test_type: int) -> None:
+    """
+    Test that assertions are running in Eigen. 
+
+    Each test is a different assertion that should be triggered in Eigen.  All tests are
+    expected to pass in normal execution.
+
+    Parameters
+    ----------
+    test_type : int
+        The type of assertion test to run, (1, 2, or 3).
     """

--- a/gropt/gropt_wrapper.pyi
+++ b/gropt/gropt_wrapper.pyi
@@ -6,7 +6,7 @@ import numpy
 from numpy.typing import NDArray
 
 
-__build_date__: str = 'Mar 11 2026 17:16:30'
+__build_date__: str = 'Mar 11 2026 20:06:43'
 
 def set_log_level(level: int) -> None:
     """
@@ -65,6 +65,12 @@ class SolveResult:
 
     @n_feval.setter
     def n_feval(self, arg: int, /) -> None: ...
+
+    @property
+    def dt(self) -> float: ...
+
+    @dt.setter
+    def dt(self, arg: float, /) -> None: ...
 
     def __repr__(self) -> str: ...
 

--- a/gropt/gropt_wrapper.pyi
+++ b/gropt/gropt_wrapper.pyi
@@ -6,7 +6,7 @@ import numpy
 from numpy.typing import NDArray
 
 
-__build_date__: str = 'Mar 11 2026 21:02:43'
+__build_date__: str = 'Mar 11 2026 21:46:53'
 
 def set_log_level(level: int) -> None:
     """

--- a/gropt/gropt_wrapper.pyi
+++ b/gropt/gropt_wrapper.pyi
@@ -1,3 +1,5 @@
+"""GrOpt: Gradient Optimization for MRI"""
+
 from collections.abc import Callable
 import enum
 from typing import Annotated, overload

--- a/gropt/gropt_wrapper.pyi
+++ b/gropt/gropt_wrapper.pyi
@@ -6,7 +6,7 @@ import numpy
 from numpy.typing import NDArray
 
 
-__build_date__: str = 'Mar  4 2026 11:50:37'
+__build_date__: str = 'Mar 11 2026 17:16:30'
 
 def set_log_level(level: int) -> None:
     """
@@ -184,6 +184,18 @@ class GroptParams:
             Weighting factor for this constraint.
         """
 
+    def add_concomitant(self, rot_variant: bool = True, weight_mod: float = 1.0) -> None:
+        """
+        Add a concomitant constraint.
+
+        Parameters
+        ----------
+        rot_variant : bool, optional
+            If True, use rotationally invariant formulation.
+        weight_mod : float, optional
+            Weighting factor for this constraint.
+        """
+
     def add_smax(self, smax: float = 80.0, rot_variant: bool = True, weight_mod: float = 1.0) -> None:
         """
         Add a maximum gradient slew rate constraint.
@@ -311,6 +323,13 @@ class GroptParams:
 
         Allocates vectors and sets up initial optimization variables.
         Automatically called by solve() if not already done.
+        """
+
+    def print_op_details(self) -> None:
+        """
+        Print details of all operators.
+
+        This function prints information about each operator in the problem, including their types and parameters.
         """
 
     def reset_op_weights(self) -> None:
@@ -550,6 +569,25 @@ def estimate_spec_norm(gparams: GroptParams, n_iters: int = 20) -> float:
         The problem definition (must have operators prepared).
     n_iters : int, optional
         Number of power iterations.
+
+    Returns
+    -------
+    float
+        Estimated spectral norm.
+    """
+
+def estimate_individual_spec_norm(gparams: GroptParams, n_iters: int = 20, op_idx: int = 0) -> float:
+    """
+    Estimate the spectral norm of a single operator matrix via power iteration.
+
+    Parameters
+    ----------
+    gparams : GroptParams
+        The problem definition (must have operators prepared).
+    n_iters : int, optional
+        Number of power iterations.
+    op_idx : int, optional
+        Index of the operator for which to estimate the spectral norm.
 
     Returns
     -------

--- a/gropt/gropt_wrapper/gropt_wrapper.cpp
+++ b/gropt/gropt_wrapper/gropt_wrapper.cpp
@@ -143,6 +143,26 @@ T_readout : float, optional
     Time to TE of the readout in seconds.)doc"
         )
 
+        // diff_init
+        .def("diff_init_deadtime", &Gropt::GroptParams::diff_init_deadtime,
+            "dt"_a = 400e-6, "TE"_a = 80e-3, "T_90"_a = 3e-3, "T_180"_a = 5e-3, "T_readout"_a = 16e-3,
+R"doc(Initialize diffusion sequence parameters, but with forced deadtime to make "convnetional" waveforms.
+
+Parameters
+----------
+dt : float, optional
+    Raster time in seconds.
+TE : float, optional
+    Echo time in seconds.
+T_90 : float, optional
+    Duration of excitation RF pulse in seconds (time from excitation,
+    so half of full RF pulse duration).
+T_180 : float, optional
+    Duration of refocusing RF pulse in seconds.
+T_readout : float, optional
+    Time to TE of the readout in seconds.)doc"
+        )
+
         // setvec_X0 — accepts numpy array, infers N/Naxis from shape
         .def("setvec_X0", [](Gropt::GroptParams &self, nb::ndarray<double, nb::ndim<1>> X0, bool set_others) {
             Eigen::Map<const Eigen::VectorXd> x(X0.data(), X0.shape(0));

--- a/gropt/gropt_wrapper/gropt_wrapper.cpp
+++ b/gropt/gropt_wrapper/gropt_wrapper.cpp
@@ -1,6 +1,7 @@
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/pair.h>
+#include <nanobind/stl/vector.h>
 #include <nanobind/eigen/dense.h>
 
 #include "spdlog/spdlog.h"
@@ -17,6 +18,7 @@ using namespace nb::literals;
 
 NB_MODULE(gropt_wrapper, m) {
     m.doc() = "GrOpt: Gradient Optimization for MRI";
+    m.attr("__build_date__") = __DATE__ " " __TIME__;
 
 
     // These allow you to get spdlogs into jupyter notebooks
@@ -408,32 +410,48 @@ operator in all_op and all_obj.)doc"
     
     //////////////////////////////////////////////////////////
     // -------------------------------------------------------
-    // SolverGroptSDMM
+    // Solver (base class)
     // -------------------------------------------------------
-    nb::class_<Gropt::SolverGroptSDMM>(m, "SolverGroptSDMM",
-        "SDMM solver for GrOpt gradient optimization problems.")
-        .def(nb::init<>())
+    nb::class_<Gropt::Solver>(m, "Solver")
+        .def_rw("extra_debug", &Gropt::Solver::extra_debug,
+            "If True, populate debug_solver with per-iteration history after solve().")
+        .def("get_debug", [](Gropt::Solver &self) {
+            nb::dict d;
+            d["hist_X"]   = self.debug_solver.hist_X;
+            d["hist_Ax"]  = self.debug_solver.hist_Ax;
+            d["hist_z"]   = self.debug_solver.hist_z;
+            d["hist_y"]   = self.debug_solver.hist_y;
+            d["hist_Aty"] = self.debug_solver.hist_Aty;
+            return d;
+        },
+R"doc(Return debug history as a dict of lists of numpy arrays.
 
-        .def("set_general_params", &Gropt::SolverGroptSDMM::set_general_params,
+Only populated when extra_debug=True before solve().
+
+Returns
+-------
+dict with keys: hist_X, hist_Ax, hist_z, hist_y, hist_Aty
+    Each value is a list of 1-D numpy arrays, one per logged iteration.)doc"
+        )
+        .def("set_general_params", &Gropt::Solver::set_general_params,
             "min_iter"_a = 1, "max_iter"_a = 2000, "log_interval"_a = 20,
             "gamma_x"_a = 1.6, "max_feval"_a = 12000,
 R"doc(Set general solver parameters.
 
-Parameters 
+Parameters
 ----------
 min_iter : int, optional
-    Minimum SDMM iterations.
+    Minimum iterations.
 max_iter : int, optional
-    Maximum SDMM iterations.
+    Maximum iterations.
 log_interval : int, optional
     Logging interval (only visible with verbose logging).
 gamma_x : float, optional
-    Relaxation parameter for SDMM updates.
+    Relaxation parameter for updates.
 max_feval : int, optional
     Maximum total function evaluations.)doc"
         )
-
-        .def("set_ils_params", &Gropt::SolverGroptSDMM::set_ils_params,
+        .def("set_ils_params", &Gropt::Solver::set_ils_params,
             "ils_tol"_a = 1e-3, "ils_max_iter"_a = 20, "ils_min_iter"_a = 2,
             "ils_sigma"_a = 1e-4, "ils_tik_lam"_a = 0.0,
 R"doc(Set indirect linear solver parameters.
@@ -443,14 +461,23 @@ Parameters
 ils_tol : float, optional
     Relative tolerance for the inner solver.
 ils_max_iter : int, optional
-    Maximum ILS iterations per SDMM iteration.
+    Maximum ILS iterations per outer iteration.
 ils_min_iter : int, optional
     Minimum ILS iterations.
 ils_sigma : float, optional
     ADMM penalty parameter.
 ils_tik_lam : float, optional
     Tikhonov regularization parameter.)doc"
-        )
+        );
+
+
+    //////////////////////////////////////////////////////////
+    // -------------------------------------------------------
+    // SolverGroptSDMM
+    // -------------------------------------------------------
+    nb::class_<Gropt::SolverGroptSDMM, Gropt::Solver>(m, "SolverGroptSDMM",
+        "SDMM solver for GrOpt gradient optimization problems.")
+        .def(nb::init<>())
 
         .def("set_sdmm_params", &Gropt::SolverGroptSDMM::set_sdmm_params,
             "rw_interval"_a = 8, "rw_e_corr"_a = 0.4, "rw_eps"_a = 1e-36,
@@ -500,47 +527,9 @@ SolveResult
     // -------------------------------------------------------
     // SolverOSQP
     // -------------------------------------------------------
-    nb::class_<Gropt::SolverOSQP>(m, "SolverOSQP",
+    nb::class_<Gropt::SolverOSQP, Gropt::Solver>(m, "SolverOSQP",
         "OSQP solver for GrOpt gradient optimization problems.")
         .def(nb::init<>())
-
-        .def("set_general_params", &Gropt::SolverOSQP::set_general_params,
-            "min_iter"_a = 1, "max_iter"_a = 2000, "log_interval"_a = 20,
-            "gamma_x"_a = 1.6, "max_feval"_a = 12000,
-R"doc(Set general solver parameters.
-
-Parameters 
-----------
-min_iter : int, optional
-    Minimum OSQP iterations.
-max_iter : int, optional
-    Maximum OSQP iterations.
-log_interval : int, optional
-    Logging interval (only visible with verbose logging).
-gamma_x : float, optional
-    Relaxation parameter for OSQP updates.
-max_feval : int, optional
-    Maximum total function evaluations.)doc"
-        )
-
-        .def("set_ils_params", &Gropt::SolverOSQP::set_ils_params,
-            "ils_tol"_a = 1e-3, "ils_max_iter"_a = 20, "ils_min_iter"_a = 2,
-            "ils_sigma"_a = 1e-4, "ils_tik_lam"_a = 0.0,
-R"doc(Set indirect linear solver parameters.
-
-Parameters
-----------
-ils_tol : float, optional
-    Relative tolerance for the inner solver.
-ils_max_iter : int, optional
-    Maximum ILS iterations per OSQP iteration.
-ils_min_iter : int, optional
-    Minimum ILS iterations.
-ils_sigma : float, optional
-    ADMM penalty parameter.
-ils_tik_lam : float, optional
-    Tikhonov regularization parameter.)doc"
-        )
 
         .def("solve", [](Gropt::SolverOSQP &self, Gropt::GroptParams &gparams) {
             Gropt::SolveResult result = self.solve(gparams);

--- a/gropt/gropt_wrapper/gropt_wrapper.cpp
+++ b/gropt/gropt_wrapper/gropt_wrapper.cpp
@@ -461,7 +461,7 @@ dict with keys: hist_X, hist_Ax, hist_z, hist_y, hist_Aty
         )
         .def("set_general_params", &Gropt::Solver::set_general_params,
             "min_iter"_a = 1, "max_iter"_a = 2000, "log_interval"_a = 20,
-            "gamma_x"_a = 1.6, "max_feval"_a = 12000,
+            "gamma_x"_a = 1.6, "max_feval"_a = 12000, "extra_iters"_a = 0,
 R"doc(Set general solver parameters.
 
 Parameters
@@ -475,8 +475,11 @@ log_interval : int, optional
 gamma_x : float, optional
     Relaxation parameter for updates.
 max_feval : int, optional
-    Maximum total function evaluations.)doc"
+    Maximum total function evaluations.
+extra_iters : int, optional
+    Number of extra iterations to run after solution is found.)doc"
         )
+
         .def("set_ils_params", &Gropt::Solver::set_ils_params,
             "ils_tol"_a = 1e-3, "ils_max_iter"_a = 20, "ils_min_iter"_a = 2,
             "ils_sigma"_a = 1e-4, "ils_tik_lam"_a = 0.0,
@@ -583,15 +586,15 @@ SolveResult
 
     // solve() convenience function
     m.def("solve", [](Gropt::GroptParams &params,
-                      int min_iter, int max_iter, int log_interval, double gamma_x, int max_feval,
+                      int min_iter, int max_iter, int log_interval, double gamma_x, int max_feval, int extra_iters,
                       double ils_tol, int ils_max_iter, int ils_min_iter, double ils_sigma, double ils_tik_lam) {
         Gropt::SolverGroptSDMM solver;
-        solver.set_general_params(min_iter, max_iter, log_interval, gamma_x, max_feval);
+        solver.set_general_params(min_iter, max_iter, log_interval, gamma_x, max_feval, extra_iters);
         solver.set_ils_params(ils_tol, ils_max_iter, ils_min_iter, ils_sigma, ils_tik_lam);
         return solver.solve(params);
     }, "params"_a,
        "min_iter"_a = 1, "max_iter"_a = 2000, "log_interval"_a = 20,
-       "gamma_x"_a = 1.6, "max_feval"_a = 12000,
+       "gamma_x"_a = 1.6, "max_feval"_a = 12000, "extra_iters"_a = 0,
        "ils_tol"_a = 1e-3, "ils_max_iter"_a = 20, "ils_min_iter"_a = 2,
        "ils_sigma"_a = 1e-4, "ils_tik_lam"_a = 0.0,
 R"doc(Convenience function to solve a GrOpt problem.

--- a/gropt/gropt_wrapper/gropt_wrapper.cpp
+++ b/gropt/gropt_wrapper/gropt_wrapper.cpp
@@ -754,4 +754,19 @@ Returns
 np.ndarray
     SAFE response curve.)doc"
     );
+
+    m.def("_test_eigen_assertions", &Gropt::test_eigen_assertions,
+        "test_type"_a,
+R"doc(Test that assertions are running in Eigen. 
+
+Each test is a different assertion that should be triggered in Eigen.  All tests are
+expected to pass in normal execution.
+
+Parameters
+----------
+test_type : int
+    The type of assertion test to run, (1, 2, or 3).)doc"
+    );
+
+    
 }

--- a/gropt/gropt_wrapper/gropt_wrapper.cpp
+++ b/gropt/gropt_wrapper/gropt_wrapper.cpp
@@ -71,6 +71,7 @@ n_feval : int
         .def_rw("converged", &Gropt::SolveResult::converged)
         .def_rw("n_iter", &Gropt::SolveResult::n_iter)
         .def_rw("n_feval", &Gropt::SolveResult::n_feval)
+        .def_rw("dt", &Gropt::SolveResult::dt)
         .def("__repr__", [](const Gropt::SolveResult &r) {
             return "SolveResult(converged=" + std::string(r.converged ? "True" : "False") +
                    ", n_iter=" + std::to_string(r.n_iter) +
@@ -198,6 +199,20 @@ Parameters
 ----------
 gmax : float, optional
     Maximum allowed gradient magnitude [T/m].
+rot_variant : bool, optional
+    If True, use rotationally invariant formulation.
+weight_mod : float, optional
+    Weighting factor for this constraint.)doc"
+        )
+
+
+        // add_concomitant
+        .def("add_concomitant", &Gropt::GroptParams::add_concomitant,
+            "rot_variant"_a = true, "weight_mod"_a = 1.0,
+R"doc(Add a concomitant constraint.
+
+Parameters
+----------
 rot_variant : bool, optional
     If True, use rotationally invariant formulation.
 weight_mod : float, optional
@@ -399,6 +414,14 @@ Allocates vectors and sets up initial optimization variables.
 Automatically called by solve() if not already done.)doc"
         )
 
+        // print_op_details
+        .def("print_op_details", &Gropt::GroptParams::print_op_details,
+R"doc(Print details of all operators.
+
+This function prints information about each operator in the problem, including their types and parameters.)doc"
+        )
+
+        
         // reset_op_weights
         .def("reset_op_weights", &Gropt::GroptParams::reset_op_weights,
 R"doc(Reset all operator weights and spectral norms to 1.0.
@@ -422,6 +445,9 @@ operator in all_op and all_obj.)doc"
             d["hist_z"]   = self.debug_solver.hist_z;
             d["hist_y"]   = self.debug_solver.hist_y;
             d["hist_Aty"] = self.debug_solver.hist_Aty;
+            d["hist_weight"] = self.debug_solver.hist_weight;
+            d["hist_gamma"] = self.debug_solver.hist_gamma;
+            d["hist_gamma_x"] = self.debug_solver.hist_gamma_x;
             return d;
         },
 R"doc(Return debug history as a dict of lists of numpy arrays.
@@ -694,6 +720,30 @@ Returns
 float
     Estimated spectral norm.)doc"
     );
+
+        // estimate_spec_norm
+    m.def("estimate_individual_spec_norm", &Gropt::estimate_individual_spec_norm,
+        "gparams"_a, "n_iters"_a = 20, "op_idx"_a = 0,
+R"doc(Estimate the spectral norm of a single operator matrix via power iteration.
+
+Parameters
+----------
+gparams : GroptParams
+    The problem definition (must have operators prepared).
+n_iters : int, optional
+    Number of power iterations.
+op_idx : int, optional
+    Index of the operator for which to estimate the spectral norm.
+
+Returns
+-------
+float
+    Estimated spectral norm.)doc"
+    );
+
+
+
+    
 
     // get_SAFE
     m.def("get_SAFE", [](Eigen::VectorXd G, double dt, bool true_safe,

--- a/gropt/gropt_wrapper/gropt_wrapper.cpp
+++ b/gropt/gropt_wrapper/gropt_wrapper.cpp
@@ -755,7 +755,7 @@ np.ndarray
     SAFE response curve.)doc"
     );
 
-    m.def("_test_eigen_assertions", &Gropt::test_eigen_assertions,
+    m.def("test_eigen_assertions", &Gropt::test_eigen_assertions,
         "test_type"_a,
 R"doc(Test that assertions are running in Eigen. 
 

--- a/gropt/src/equilibrate.cpp
+++ b/gropt/src/equilibrate.cpp
@@ -22,6 +22,7 @@ void equilibrate(GroptParams &gparams, int n_iter, int n_reps) {
         col_norms = col_norms.cwiseSqrt().cwiseInverse();
 
         // TODO: This should be all axis
+        // TODO: Also check how this affects convergence, there is something important about these points with slew rate
         col_norms[0] = col_norms[1];
         col_norms[col_norms.size() - 1] = col_norms[col_norms.size() - 2];
 
@@ -92,6 +93,8 @@ void estimate_row_col_norms(GroptParams &gparams, int n_reps, NormType norm_type
     row_norms.setZero(N_rows);
     col_norms.setZero(N_cols);
 
+    spdlog::trace("N_rows {}   N_cols {}", N_rows, N_cols);
+
     // Row norm reps
     for (int rep = 0; rep < n_reps; rep++) {
         Eigen::VectorXd z = Eigen::VectorXd::Random(N_cols).array().sign();
@@ -109,6 +112,8 @@ void estimate_row_col_norms(GroptParams &gparams, int n_reps, NormType norm_type
             row_start += op->Ax_size;
         }
     }
+
+    spdlog::trace("After row norms");
 
     // Col norm reps
     for (int rep = 0; rep < n_reps; rep++) {
@@ -128,6 +133,8 @@ void estimate_row_col_norms(GroptParams &gparams, int n_reps, NormType norm_type
             col_norms = col_norms.cwiseMax(Atw.cwiseAbs());
         }
     }
+
+    spdlog::trace("After col norms");
 
     if (norm_type == NormType::L2) {
         row_norms = (row_norms / n_reps).cwiseSqrt();

--- a/gropt/src/equilibrate.cpp
+++ b/gropt/src/equilibrate.cpp
@@ -166,9 +166,39 @@ double estimate_spec_norm(GroptParams &gparams, int n_iters) {
         }
         lambda_max = v_next.norm();
         v = v_next / lambda_max;
-        spdlog::debug("estimate_spec_norm iteration {}: lambda_max = {}", iter, lambda_max);
+        spdlog::debug("estimate_spec_norm iteration {}: lambda_max = {:.2e}", iter, lambda_max);
     }
 
+    spdlog::debug("Final spec_norm2 {:.2e}: spec_norm = {:.2e}", lambda_max, sqrt(lambda_max));
     return sqrt(lambda_max);
 }
+
+double estimate_individual_spec_norm(GroptParams &gparams, int n_iters, int op_idx) {
+
+    int Ntot = gparams.N * gparams.Naxis;
+
+    // Make a VectorXd of size Ntot using a standard normal distribution, and normalize it to have norm 1
+    Eigen::VectorXd v = Eigen::VectorXd::Random(Ntot);
+    v.normalize();
+
+    double lambda_max;
+    for (int iter = 0; iter < n_iters; iter++) {
+        Eigen::VectorXd v_next = Eigen::VectorXd::Zero(Ntot);
+
+        Operator *op = gparams.all_op[op_idx].get();
+        op->Ax_temp.setZero();
+        op->x_temp.setZero();
+        op->forward_op(v, op->Ax_temp);
+        op->transpose_op(op->Ax_temp, op->x_temp);
+        v_next += op->x_temp;
+
+        lambda_max = v_next.norm();
+        v = v_next / lambda_max;
+        spdlog::debug("estimate_spec_norm iteration {}: lambda_max = {:.2e}", iter, lambda_max);
+    }
+
+    spdlog::debug("Final spec_norm2 {:.2e}: spec_norm = {:.2e}", lambda_max, sqrt(lambda_max));
+    return sqrt(lambda_max);
+}
+
 } // namespace Gropt

--- a/gropt/src/equilibrate.hpp
+++ b/gropt/src/equilibrate.hpp
@@ -22,6 +22,8 @@ void equilibrate(GroptParams &gparams, int n_iter, int n_reps);
 
 double estimate_spec_norm(GroptParams &gparams, int n_iters);
 
+double estimate_individual_spec_norm(GroptParams &gparams, int n_iters, int op_idx);
+
 } // namespace Gropt
 
 #endif

--- a/gropt/src/gropt_params.cpp
+++ b/gropt/src/gropt_params.cpp
@@ -2,18 +2,17 @@
 
 #include "gropt_params.hpp"
 
-#include "op_gradient.hpp"
-#include "op_moment.hpp"
-#include "op_slew.hpp"
-#include "op_identity.hpp"
 #include "op_bvalue.hpp"
+#include "op_gradient.hpp"
+#include "op_identity.hpp"
+#include "op_moment.hpp"
 #include "op_safe.hpp"
+#include "op_slew.hpp"
 #include "op_tv.hpp"
 
 namespace Gropt {
 
-GroptParams::GroptParams() {
-}
+GroptParams::GroptParams() {}
 
 void GroptParams::vec_init_simple(int _N, int _Naxis, double first_val, double last_val) {
     if (_N > 0) {
@@ -31,16 +30,16 @@ void GroptParams::vec_init_simple(int _N, int _Naxis, double first_val, double l
     pdata.set_vals.setZero(N * Naxis);
     pdata.set_vals.array() *= NAN;
     pdata.set_vals(0) = first_val;
-    pdata.set_vals(N-1) = last_val;
+    pdata.set_vals(N - 1) = last_val;
 
     pdata.fixer.setOnes(N * Naxis);
     pdata.fixer(0) = 0.0;
-    pdata.fixer(N-1) = 0.0;
+    pdata.fixer(N - 1) = 0.0;
 
     pdata.X0.setOnes(N * Naxis);
     pdata.X0 *= .01;
     pdata.X0(0) = first_val;
-    pdata.X0(N-1) = last_val;
+    pdata.X0(N - 1) = last_val;
 
     vec_init_status = N;
 }
@@ -57,7 +56,7 @@ void GroptParams::setvec_X0(int _N, int _Naxis, double *_X0, bool set_others) {
     Ntot = N * Naxis;
 
     pdata.X0.setOnes(N * Naxis);
-    for (int i=0; i<N * Naxis; i++) {
+    for (int i = 0; i < N * Naxis; i++) {
         pdata.X0(i) = _X0[i];
     }
 
@@ -70,11 +69,11 @@ void GroptParams::setvec_X0(int _N, int _Naxis, double *_X0, bool set_others) {
         pdata.fixer.setOnes(N * Naxis);
 
         for (int j = 0; j < Naxis; j++) {
-            pdata.set_vals((j*N)) = pdata.X0((j*N));
-            pdata.set_vals((j*N) + N-1) = pdata.X0((j*N) + N-1);
+            pdata.set_vals((j * N)) = pdata.X0((j * N));
+            pdata.set_vals((j * N) + N - 1) = pdata.X0((j * N) + N - 1);
 
-            pdata.fixer((j*N)) = 0.0;
-            pdata.fixer((j*N) + N-1) = 0.0;
+            pdata.fixer((j * N)) = 0.0;
+            pdata.fixer((j * N) + N - 1) = 0.0;
         }
     }
 
@@ -84,7 +83,7 @@ void GroptParams::setvec_X0(int _N, int _Naxis, double *_X0, bool set_others) {
 void GroptParams::setvec_X0(const Eigen::VectorXd &_X0, int _Naxis, bool set_others) {
     int _N = static_cast<int>(_X0.size()) / _Naxis;
     // const_cast is safe here — the raw-pointer overload only reads from the data
-    setvec_X0(_N, _Naxis, const_cast<double*>(_X0.data()), set_others);
+    setvec_X0(_N, _Naxis, const_cast<double *>(_X0.data()), set_others);
 }
 
 void GroptParams::diff_init(double _dt, double _TE, double _T_90, double _T_180, double _T_readout) {
@@ -96,55 +95,51 @@ void GroptParams::diff_init(double _dt, double _TE, double _T_90, double _T_180,
     double T_readout = _T_readout;
     double TE = _TE;
 
-    N = (int)((TE-T_readout)/dt) + 1;
+    N = (int)((TE - T_readout) / dt) + 1;
     Ntot = N * Naxis;
 
-    int ind_inv = (int)(TE/2.0/dt);
+    int ind_inv = (int)(TE / 2.0 / dt);
     pdata.inv_vec.setOnes(N);
-    for(int i = ind_inv; i < N; i++) {
+    for (int i = ind_inv; i < N; i++) {
         pdata.inv_vec(i) = -1.0;
     }
 
     int ind_90_end, ind_180_start, ind_180_end;
-    ind_90_end = ceil(T_90/dt);
-    ind_180_start = floor((TE/2.0 - T_180/2.0)/dt);
-    ind_180_end = ceil((TE/2.0 + T_180/2.0)/dt);
+    ind_90_end = ceil(T_90 / dt);
+    ind_180_start = floor((TE / 2.0 - T_180 / 2.0) / dt);
+    ind_180_end = ceil((TE / 2.0 + T_180 / 2.0) / dt);
 
     pdata.set_vals.setOnes(N);
     pdata.set_vals.array() *= NAN;
-    for(int i = 0; i <= ind_90_end; i++) {
+    for (int i = 0; i <= ind_90_end; i++) {
         pdata.set_vals(i) = 0.0;
     }
-    for(int i = ind_180_start; i <= ind_180_end; i++) {
+    for (int i = ind_180_start; i <= ind_180_end; i++) {
         pdata.set_vals(i) = 0.0;
     }
     pdata.set_vals(0) = 0.0;
-    pdata.set_vals(N-1) = 0.0;
-
+    pdata.set_vals(N - 1) = 0.0;
 
     pdata.fixer.setOnes(N);
-    for(int i = 0; i < pdata.set_vals.size(); i++) {
+    for (int i = 0; i < pdata.set_vals.size(); i++) {
         if (!isnan(pdata.set_vals(i))) {
             pdata.fixer(i) = 0.0;
         }
     }
 
-
     pdata.X0.setOnes(N);
-    for(int i = 0; i < pdata.set_vals.size(); i++) {
+    for (int i = 0; i < pdata.set_vals.size(); i++) {
         if (!isnan(pdata.set_vals(i))) {
             pdata.X0(i) = pdata.set_vals(i);
         } else {
-            pdata.X0(i) = 1e-2;  // Initial value for non-fixed points
+            pdata.X0(i) = 1e-2; // Initial value for non-fixed points
         }
     }
 
     vec_init_status = N;
-
 }
 
-void GroptParams::set_ils_solver(std::string _ils_method)
-{
+void GroptParams::set_ils_solver(std::string _ils_method) {
     spdlog::info("set_ils_solver: {}", _ils_method);
     if (_ils_method == "CG") {
         ils_method = CG;
@@ -158,7 +153,6 @@ void GroptParams::set_ils_solver(std::string _ils_method)
     }
 }
 
-
 void GroptParams::vec_reduce_simple(int N_reduce) {
     N -= N_reduce;
     Ntot = N * Naxis;
@@ -169,12 +163,12 @@ void GroptParams::vec_reduce_simple(int N_reduce) {
     set_vals_new.setZero(N * Naxis);
     set_vals_new.array() *= NAN;
     set_vals_new(0) = pdata.set_vals(0);
-    set_vals_new(N-1) = pdata.set_vals(pdata.set_vals.size()-1);
+    set_vals_new(N - 1) = pdata.set_vals(pdata.set_vals.size() - 1);
 
     Eigen::VectorXd fixer_new;
     fixer_new.setOnes(N * Naxis);
     fixer_new(0) = 0.0;
-    fixer_new(N-1) = 0.0;
+    fixer_new(N - 1) = 0.0;
 
     pdata.set_vals = set_vals_new;
     pdata.fixer = fixer_new;
@@ -186,7 +180,7 @@ void GroptParams::prepare() {
 
     spdlog::trace("GroptParams::prepare() start");
 
-    if (N*Naxis != Ntot) {
+    if (N * Naxis != Ntot) {
         Ntot = N * Naxis;
         spdlog::warn("Ntot is not consistent with N and Naxis");
         spdlog::warn("Setting Ntot = {}", Ntot);
@@ -217,19 +211,15 @@ void GroptParams::add_smax(double smax, bool rot_variant, double weight_mod) {
     all_op.push_back(std::make_unique<Op_Slew>(pdata, smax, rot_variant, weight_mod));
 }
 
-void GroptParams::add_moment(double order, double target,
-                             double tol0, std::string units, int moment_axis,
+void GroptParams::add_moment(double order, double target, double tol0, std::string units, int moment_axis,
                              int start_idx0, int stop_idx0, int ref_idx0, double weight_mod) {
-    all_op.push_back(std::make_unique<Op_Moment>(pdata, order, target, tol0, units,
-                                   moment_axis, start_idx0, stop_idx0, ref_idx0, weight_mod));
+    all_op.push_back(std::make_unique<Op_Moment>(pdata, order, target, tol0, units, moment_axis, start_idx0, stop_idx0,
+                                                 ref_idx0, weight_mod));
 }
 
-void GroptParams::add_SAFE(double stim_thresh,
-                           double *tau1, double *tau2, double *tau3,
-                           double *a1, double *a2, double *a3,
-                           double *stim_limit, double *g_scale,
-                           int new_first_axis, bool demo_params, double weight_mod)
-{
+void GroptParams::add_SAFE(double stim_thresh, double *tau1, double *tau2, double *tau3, double *a1, double *a2,
+                           double *a3, double *stim_limit, double *g_scale, int new_first_axis, bool demo_params,
+                           double weight_mod) {
     auto op_F = std::make_unique<Op_SAFE>(pdata, stim_thresh, weight_mod);
     if (demo_params) {
         op_F->safe_params.set_demo_params();
@@ -240,13 +230,9 @@ void GroptParams::add_SAFE(double stim_thresh,
     all_op.push_back(std::move(op_F));
 }
 
-void GroptParams::add_SAFE_vec(int N_vec, double *stim_thresh_vec,
-                      double *tau1, double *tau2, double *tau3,
-                      double *a1, double *a2, double *a3,
-                      double *stim_limit, double *g_scale,
-                      int new_first_axis, bool demo_params,
-                      double weight_mod)
-{
+void GroptParams::add_SAFE_vec(int N_vec, double *stim_thresh_vec, double *tau1, double *tau2, double *tau3, double *a1,
+                               double *a2, double *a3, double *stim_limit, double *g_scale, int new_first_axis,
+                               bool demo_params, double weight_mod) {
     auto op_F = std::make_unique<Op_SAFE>(pdata, N_vec, stim_thresh_vec, weight_mod);
     if (demo_params) {
         op_F->safe_params.set_demo_params();
@@ -257,7 +243,6 @@ void GroptParams::add_SAFE_vec(int N_vec, double *stim_thresh_vec,
     all_op.push_back(std::move(op_F));
 }
 
-
 void GroptParams::add_SAFE(double stim_thresh, int new_first_axis, double weight_mod) {
     auto op_F = std::make_unique<Op_SAFE>(pdata, stim_thresh, weight_mod);
     op_F->safe_params.set_demo_params();
@@ -265,56 +250,49 @@ void GroptParams::add_SAFE(double stim_thresh, int new_first_axis, double weight
     all_op.push_back(std::move(op_F));
 }
 
-void GroptParams::add_SAFE(double stim_thresh,
-                           const Eigen::VectorXd &tau1, const Eigen::VectorXd &tau2, const Eigen::VectorXd &tau3,
-                           const Eigen::VectorXd &a1, const Eigen::VectorXd &a2, const Eigen::VectorXd &a3,
-                           const Eigen::VectorXd &stim_limit, const Eigen::VectorXd &g_scale,
-                           int new_first_axis, double weight_mod)
-{
+void GroptParams::add_SAFE(double stim_thresh, const Eigen::VectorXd &tau1, const Eigen::VectorXd &tau2,
+                           const Eigen::VectorXd &tau3, const Eigen::VectorXd &a1, const Eigen::VectorXd &a2,
+                           const Eigen::VectorXd &a3, const Eigen::VectorXd &stim_limit, const Eigen::VectorXd &g_scale,
+                           int new_first_axis, double weight_mod) {
     auto op_F = std::make_unique<Op_SAFE>(pdata, stim_thresh, weight_mod);
-    op_F->safe_params.set_params(
-        const_cast<double*>(tau1.data()), const_cast<double*>(tau2.data()), const_cast<double*>(tau3.data()),
-        const_cast<double*>(a1.data()), const_cast<double*>(a2.data()), const_cast<double*>(a3.data()),
-        const_cast<double*>(stim_limit.data()), const_cast<double*>(g_scale.data()));
+    op_F->safe_params.set_params(const_cast<double *>(tau1.data()), const_cast<double *>(tau2.data()),
+                                 const_cast<double *>(tau3.data()), const_cast<double *>(a1.data()),
+                                 const_cast<double *>(a2.data()), const_cast<double *>(a3.data()),
+                                 const_cast<double *>(stim_limit.data()), const_cast<double *>(g_scale.data()));
     op_F->safe_params.swap_first_axes(new_first_axis);
     all_op.push_back(std::move(op_F));
 }
 
 void GroptParams::add_SAFE_vec(const Eigen::VectorXd &stim_thresh_vec, int new_first_axis, double weight_mod) {
     auto op_F = std::make_unique<Op_SAFE>(pdata, static_cast<int>(stim_thresh_vec.size()),
-                                          const_cast<double*>(stim_thresh_vec.data()), weight_mod);
+                                          const_cast<double *>(stim_thresh_vec.data()), weight_mod);
     op_F->safe_params.set_demo_params();
     op_F->safe_params.swap_first_axes(new_first_axis);
     all_op.push_back(std::move(op_F));
 }
 
-void GroptParams::add_SAFE_vec(const Eigen::VectorXd &stim_thresh_vec,
-                               const Eigen::VectorXd &tau1, const Eigen::VectorXd &tau2, const Eigen::VectorXd &tau3,
-                               const Eigen::VectorXd &a1, const Eigen::VectorXd &a2, const Eigen::VectorXd &a3,
-                               const Eigen::VectorXd &stim_limit, const Eigen::VectorXd &g_scale,
-                               int new_first_axis, double weight_mod)
-{
+void GroptParams::add_SAFE_vec(const Eigen::VectorXd &stim_thresh_vec, const Eigen::VectorXd &tau1,
+                               const Eigen::VectorXd &tau2, const Eigen::VectorXd &tau3, const Eigen::VectorXd &a1,
+                               const Eigen::VectorXd &a2, const Eigen::VectorXd &a3, const Eigen::VectorXd &stim_limit,
+                               const Eigen::VectorXd &g_scale, int new_first_axis, double weight_mod) {
     auto op_F = std::make_unique<Op_SAFE>(pdata, static_cast<int>(stim_thresh_vec.size()),
-                                          const_cast<double*>(stim_thresh_vec.data()), weight_mod);
-    op_F->safe_params.set_params(
-        const_cast<double*>(tau1.data()), const_cast<double*>(tau2.data()), const_cast<double*>(tau3.data()),
-        const_cast<double*>(a1.data()), const_cast<double*>(a2.data()), const_cast<double*>(a3.data()),
-        const_cast<double*>(stim_limit.data()), const_cast<double*>(g_scale.data()));
+                                          const_cast<double *>(stim_thresh_vec.data()), weight_mod);
+    op_F->safe_params.set_params(const_cast<double *>(tau1.data()), const_cast<double *>(tau2.data()),
+                                 const_cast<double *>(tau3.data()), const_cast<double *>(a1.data()),
+                                 const_cast<double *>(a2.data()), const_cast<double *>(a3.data()),
+                                 const_cast<double *>(stim_limit.data()), const_cast<double *>(g_scale.data()));
     op_F->safe_params.swap_first_axes(new_first_axis);
     all_op.push_back(std::move(op_F));
 }
 
-void GroptParams::add_bvalue(double target, double tol,
-                             int start_idx0, int stop_idx0, double weight_mod,
-                             int mode, double max_scale) {
+void GroptParams::add_bvalue(double target, double tol, int start_idx0, int stop_idx0, double weight_mod, int mode,
+                             double max_scale) {
 
-    all_op.push_back(std::make_unique<Op_BValue>(pdata, target, tol,
-                     start_idx0, stop_idx0, weight_mod,
-                     static_cast<BVALUE_MODE>(mode), max_scale));
+    all_op.push_back(std::make_unique<Op_BValue>(pdata, target, tol, start_idx0, stop_idx0, weight_mod,
+                                                 static_cast<BVALUE_MODE>(mode), max_scale));
 }
 
-void GroptParams::add_TV(double tv_lam, double weight_mod)
-{
+void GroptParams::add_TV(double tv_lam, double weight_mod) {
     all_op.push_back(std::make_unique<Op_TV>(pdata, tv_lam, weight_mod));
 }
 
@@ -324,27 +302,25 @@ void GroptParams::add_obj_identity(double weight_mod) {
 
 void GroptParams::reset_op_weights() {
     for (auto &op : all_op) {
-        op->weight_mod = 1.0;
+        // op->weight_mod = 1.0;
         op->spec_norm = 1.0;
         op->spec_norm2 = 1.0;
     }
     for (auto &op : all_obj) {
-        op->weight_mod = 1.0;
+        // op->weight_mod = 1.0;
         op->spec_norm = 1.0;
         op->spec_norm2 = 1.0;
     }
 }
 
 double GroptParams::get_output_bvalue(const Eigen::VectorXd &X) {
-    Op_BValue opB(pdata, 1, 1,
-                     -1, -1, 1,
-                     static_cast<BVALUE_MODE>(1), 1.01);
+    Op_BValue opB(pdata, 1, 1, -1, -1, 1, static_cast<BVALUE_MODE>(1), 1.01);
     opB.init();
     Eigen::VectorXd X_copy = X;
     return opB.get_bvalue(X_copy);
 }
 
-Eigen::VectorXd linear_interpolate(const Eigen::VectorXd& in, int out_size) {
+Eigen::VectorXd linear_interpolate(const Eigen::VectorXd &in, int out_size) {
     int in_size = in.size();
     if (out_size >= in_size) {
         return in;
@@ -369,6 +345,5 @@ Eigen::VectorXd linear_interpolate(const Eigen::VectorXd& in, int out_size) {
     }
     return out;
 }
-
 
 } // namespace Gropt

--- a/gropt/src/gropt_params.cpp
+++ b/gropt/src/gropt_params.cpp
@@ -133,6 +133,61 @@ void GroptParams::diff_init(double _dt, double _TE, double _T_90, double _T_180,
     vec_init_status = N;
 }
 
+void GroptParams::diff_init_deadtime(double _dt, double _TE, double _T_90, double _T_180, double _T_readout) {
+    dt = _dt;
+    Naxis = 1;
+
+    double T_90 = _T_90;
+    double T_180 = _T_180;
+    double T_readout = _T_readout;
+    double TE = _TE;
+
+    N = (int)((TE - T_readout) / dt) + 1;
+    Ntot = N * Naxis;
+
+    int ind_inv = (int)(TE / 2.0 / dt);
+    pdata.inv_vec.setOnes(N);
+    for (int i = ind_inv; i < N; i++) {
+        pdata.inv_vec(i) = -1.0;
+    }
+
+    int ind_90_end, ind_180_start, ind_180_end;
+    ind_90_end = ceil(T_90 / dt);
+    ind_180_end = ceil((TE / 2.0 + T_180 / 2.0) / dt);
+
+    int live_time = N - ind_180_end;
+    ind_180_start = ind_90_end + live_time;
+
+    pdata.set_vals.setOnes(N);
+    pdata.set_vals.array() *= NAN;
+    for (int i = 0; i <= ind_90_end; i++) {
+        pdata.set_vals(i) = 0.0;
+    }
+    for (int i = ind_180_start; i <= ind_180_end; i++) {
+        pdata.set_vals(i) = 0.0;
+    }
+    pdata.set_vals(0) = 0.0;
+    pdata.set_vals(N - 1) = 0.0;
+
+    pdata.fixer.setOnes(N);
+    for (int i = 0; i < pdata.set_vals.size(); i++) {
+        if (!isnan(pdata.set_vals(i))) {
+            pdata.fixer(i) = 0.0;
+        }
+    }
+
+    pdata.X0.setOnes(N);
+    for (int i = 0; i < pdata.set_vals.size(); i++) {
+        if (!isnan(pdata.set_vals(i))) {
+            pdata.X0(i) = pdata.set_vals(i);
+        } else {
+            pdata.X0(i) = 1e-2; // Initial value for non-fixed points
+        }
+    }
+
+    vec_init_status = N;
+}
+
 void GroptParams::set_ils_solver(std::string _ils_method) {
     spdlog::info("set_ils_solver: {}", _ils_method);
     if (_ils_method == "CG") {

--- a/gropt/src/gropt_params.cpp
+++ b/gropt/src/gropt_params.cpp
@@ -3,6 +3,7 @@
 #include "gropt_params.hpp"
 
 #include "op_bvalue.hpp"
+#include "op_concomitant.hpp"
 #include "op_gradient.hpp"
 #include "op_identity.hpp"
 #include "op_moment.hpp"
@@ -44,7 +45,9 @@ void GroptParams::vec_init_simple(int _N, int _Naxis, double first_val, double l
     vec_init_status = N;
 }
 
-void GroptParams::setvec_X0(int _N, int _Naxis, double *_X0, bool set_others) {
+void GroptParams::setvec_X0(const Eigen::VectorXd &_X0, int _Naxis, bool set_others) {
+    int _N = static_cast<int>(_X0.size()) / _Naxis;
+
     if (_N > 0) {
         N = _N;
     }
@@ -55,10 +58,7 @@ void GroptParams::setvec_X0(int _N, int _Naxis, double *_X0, bool set_others) {
 
     Ntot = N * Naxis;
 
-    pdata.X0.setOnes(N * Naxis);
-    for (int i = 0; i < N * Naxis; i++) {
-        pdata.X0(i) = _X0[i];
-    }
+    pdata.X0 = _X0;
 
     if (set_others) {
         pdata.inv_vec.setOnes(N * Naxis);
@@ -78,12 +78,6 @@ void GroptParams::setvec_X0(int _N, int _Naxis, double *_X0, bool set_others) {
     }
 
     vec_init_status = N;
-}
-
-void GroptParams::setvec_X0(const Eigen::VectorXd &_X0, int _Naxis, bool set_others) {
-    int _N = static_cast<int>(_X0.size()) / _Naxis;
-    // const_cast is safe here — the raw-pointer overload only reads from the data
-    setvec_X0(_N, _Naxis, const_cast<double *>(_X0.data()), set_others);
 }
 
 void GroptParams::diff_init(double _dt, double _TE, double _T_90, double _T_180, double _T_readout) {
@@ -211,6 +205,10 @@ void GroptParams::add_smax(double smax, bool rot_variant, double weight_mod) {
     all_op.push_back(std::make_unique<Op_Slew>(pdata, smax, rot_variant, weight_mod));
 }
 
+void GroptParams::add_concomitant(bool rot_variant, double weight_mod) {
+    all_op.push_back(std::make_unique<Op_Concomitant>(pdata, rot_variant, weight_mod));
+}
+
 void GroptParams::add_moment(double order, double target, double tol0, std::string units, int moment_axis,
                              int start_idx0, int stop_idx0, int ref_idx0, double weight_mod) {
     all_op.push_back(std::make_unique<Op_Moment>(pdata, order, target, tol0, units, moment_axis, start_idx0, stop_idx0,
@@ -310,6 +308,15 @@ void GroptParams::reset_op_weights() {
         // op->weight_mod = 1.0;
         op->spec_norm = 1.0;
         op->spec_norm2 = 1.0;
+    }
+}
+
+void GroptParams::print_op_details() {
+    for (auto &op : all_op) {
+        op->print_details();
+    }
+    for (auto &op : all_obj) {
+        op->print_details();
     }
 }
 

--- a/gropt/src/gropt_params.cpp
+++ b/gropt/src/gropt_params.cpp
@@ -215,32 +215,6 @@ void GroptParams::add_moment(double order, double target, double tol0, std::stri
                                                  ref_idx0, weight_mod));
 }
 
-void GroptParams::add_SAFE(double stim_thresh, double *tau1, double *tau2, double *tau3, double *a1, double *a2,
-                           double *a3, double *stim_limit, double *g_scale, int new_first_axis, bool demo_params,
-                           double weight_mod) {
-    auto op_F = std::make_unique<Op_SAFE>(pdata, stim_thresh, weight_mod);
-    if (demo_params) {
-        op_F->safe_params.set_demo_params();
-    } else {
-        op_F->safe_params.set_params(tau1, tau2, tau3, a1, a2, a3, stim_limit, g_scale);
-    }
-    op_F->safe_params.swap_first_axes(new_first_axis);
-    all_op.push_back(std::move(op_F));
-}
-
-void GroptParams::add_SAFE_vec(int N_vec, double *stim_thresh_vec, double *tau1, double *tau2, double *tau3, double *a1,
-                               double *a2, double *a3, double *stim_limit, double *g_scale, int new_first_axis,
-                               bool demo_params, double weight_mod) {
-    auto op_F = std::make_unique<Op_SAFE>(pdata, N_vec, stim_thresh_vec, weight_mod);
-    if (demo_params) {
-        op_F->safe_params.set_demo_params();
-    } else {
-        op_F->safe_params.set_params(tau1, tau2, tau3, a1, a2, a3, stim_limit, g_scale);
-    }
-    op_F->safe_params.swap_first_axes(new_first_axis);
-    all_op.push_back(std::move(op_F));
-}
-
 void GroptParams::add_SAFE(double stim_thresh, int new_first_axis, double weight_mod) {
     auto op_F = std::make_unique<Op_SAFE>(pdata, stim_thresh, weight_mod);
     op_F->safe_params.set_demo_params();
@@ -253,17 +227,13 @@ void GroptParams::add_SAFE(double stim_thresh, const Eigen::VectorXd &tau1, cons
                            const Eigen::VectorXd &a3, const Eigen::VectorXd &stim_limit, const Eigen::VectorXd &g_scale,
                            int new_first_axis, double weight_mod) {
     auto op_F = std::make_unique<Op_SAFE>(pdata, stim_thresh, weight_mod);
-    op_F->safe_params.set_params(const_cast<double *>(tau1.data()), const_cast<double *>(tau2.data()),
-                                 const_cast<double *>(tau3.data()), const_cast<double *>(a1.data()),
-                                 const_cast<double *>(a2.data()), const_cast<double *>(a3.data()),
-                                 const_cast<double *>(stim_limit.data()), const_cast<double *>(g_scale.data()));
+    op_F->safe_params.set_params(tau1, tau2, tau3, a1, a2, a3, stim_limit, g_scale);
     op_F->safe_params.swap_first_axes(new_first_axis);
     all_op.push_back(std::move(op_F));
 }
 
 void GroptParams::add_SAFE_vec(const Eigen::VectorXd &stim_thresh_vec, int new_first_axis, double weight_mod) {
-    auto op_F = std::make_unique<Op_SAFE>(pdata, static_cast<int>(stim_thresh_vec.size()),
-                                          const_cast<double *>(stim_thresh_vec.data()), weight_mod);
+    auto op_F = std::make_unique<Op_SAFE>(pdata, stim_thresh_vec, weight_mod);
     op_F->safe_params.set_demo_params();
     op_F->safe_params.swap_first_axes(new_first_axis);
     all_op.push_back(std::move(op_F));
@@ -273,12 +243,8 @@ void GroptParams::add_SAFE_vec(const Eigen::VectorXd &stim_thresh_vec, const Eig
                                const Eigen::VectorXd &tau2, const Eigen::VectorXd &tau3, const Eigen::VectorXd &a1,
                                const Eigen::VectorXd &a2, const Eigen::VectorXd &a3, const Eigen::VectorXd &stim_limit,
                                const Eigen::VectorXd &g_scale, int new_first_axis, double weight_mod) {
-    auto op_F = std::make_unique<Op_SAFE>(pdata, static_cast<int>(stim_thresh_vec.size()),
-                                          const_cast<double *>(stim_thresh_vec.data()), weight_mod);
-    op_F->safe_params.set_params(const_cast<double *>(tau1.data()), const_cast<double *>(tau2.data()),
-                                 const_cast<double *>(tau3.data()), const_cast<double *>(a1.data()),
-                                 const_cast<double *>(a2.data()), const_cast<double *>(a3.data()),
-                                 const_cast<double *>(stim_limit.data()), const_cast<double *>(g_scale.data()));
+    auto op_F = std::make_unique<Op_SAFE>(pdata, stim_thresh_vec, weight_mod);
+    op_F->safe_params.set_params(tau1, tau2, tau3, a1, a2, a3, stim_limit, g_scale);
     op_F->safe_params.swap_first_axes(new_first_axis);
     all_op.push_back(std::move(op_F));
 }

--- a/gropt/src/gropt_params.hpp
+++ b/gropt/src/gropt_params.hpp
@@ -59,6 +59,7 @@ class GroptParams {
 
     void vec_init_simple(int _N, int _Naxis, double first_val, double last_val);
     void diff_init(double _dt, double _TE, double _T_90, double _T_180, double _T_readout);
+    void diff_init_deadtime(double _dt, double _TE, double _T_90, double _T_180, double _T_readout);
     void setvec_X0(const Eigen::VectorXd &_X0, int _Naxis, bool set_others);
 
     void vec_reduce_simple(int N_reduce);

--- a/gropt/src/gropt_params.hpp
+++ b/gropt/src/gropt_params.hpp
@@ -73,23 +73,13 @@ class GroptParams {
     void add_moment(double order, double target, double tol0, std::string units, int moment_axis, int start_idx0,
                     int stop_idx0, int ref_idx0, double weight_mod);
 
-    // TODO clean up all of these, they are leftover from the nanobind conversion
-    void add_SAFE(double stim_thresh, double *tau1, double *tau2, double *tau3, double *a1, double *a2, double *a3,
-                  double *stim_limit, double *g_scale, int new_first_axis, bool demo_params, double weight_mod);
-    // Eigen overload: demo params (no arrays needed)
     void add_SAFE(double stim_thresh, int new_first_axis, double weight_mod);
-    // Eigen overload: custom params
     void add_SAFE(double stim_thresh, const Eigen::VectorXd &tau1, const Eigen::VectorXd &tau2,
                   const Eigen::VectorXd &tau3, const Eigen::VectorXd &a1, const Eigen::VectorXd &a2,
                   const Eigen::VectorXd &a3, const Eigen::VectorXd &stim_limit, const Eigen::VectorXd &g_scale,
                   int new_first_axis, double weight_mod);
 
-    void add_SAFE_vec(int N_vec, double *stim_thresh_vec, double *tau1, double *tau2, double *tau3, double *a1,
-                      double *a2, double *a3, double *stim_limit, double *g_scale, int new_first_axis, bool demo_params,
-                      double weight_mod);
-    // Eigen overload: demo params
     void add_SAFE_vec(const Eigen::VectorXd &stim_thresh_vec, int new_first_axis, double weight_mod);
-    // Eigen overload: custom params
     void add_SAFE_vec(const Eigen::VectorXd &stim_thresh_vec, const Eigen::VectorXd &tau1, const Eigen::VectorXd &tau2,
                       const Eigen::VectorXd &tau3, const Eigen::VectorXd &a1, const Eigen::VectorXd &a2,
                       const Eigen::VectorXd &a3, const Eigen::VectorXd &stim_limit, const Eigen::VectorXd &g_scale,

--- a/gropt/src/gropt_params.hpp
+++ b/gropt/src/gropt_params.hpp
@@ -1,121 +1,115 @@
 #ifndef GROPT_PARAMS_H
 #define GROPT_PARAMS_H
 
+#include "Eigen/Dense"
 #include <iostream>
+#include <memory>
 #include <string>
 #include <vector>
-#include <memory>
-#include "Eigen/Dense"
 
-#include "problem_data.hpp"
 #include "op_main.hpp"
+#include "problem_data.hpp"
 
 namespace Gropt {
 
 enum ILSMethod {
-  CG,
-  NLCG,
-  BiCGstabl,
+    CG,
+    NLCG,
+    BiCGstabl,
 };
 
-class Operator;  // Forward declaration of Operator class
+class Operator; // Forward declaration of Operator class
 
 struct SolveResult {
     Eigen::VectorXd X;
     bool converged = false;
     int n_iter = 0;
     int n_feval = 0;
+    double dt = 0.0;
 };
 
-class GroptParams
-{
+class GroptParams {
 
-    public:
-        ProblemData pdata;
+  public:
+    ProblemData pdata;
 
-        // Convenience accessors that forward to pdata
-        double &dt = pdata.dt;
-        int &N = pdata.N;
-        int &Naxis = pdata.Naxis;
+    // Convenience accessors that forward to pdata
+    double &dt = pdata.dt;
+    int &N = pdata.N;
+    int &Naxis = pdata.Naxis;
 
-        int Ntot = 10;
+    int Ntot = 10;
 
-        int vec_init_status = -1;
-        int op_prep_status = -1;
+    int vec_init_status = -1;
+    int op_prep_status = -1;
 
-        std::vector<std::unique_ptr<Operator>> all_op;
-        std::vector<std::unique_ptr<Operator>> all_obj;
+    std::vector<std::unique_ptr<Operator>> all_op;
+    std::vector<std::unique_ptr<Operator>> all_obj;
 
-        ILSMethod ils_method = CG;
+    ILSMethod ils_method = CG;
 
-        GroptParams();
-        ~GroptParams() = default;
+    GroptParams();
+    ~GroptParams() = default;
 
-        // Move-only due to unique_ptr members
-        GroptParams(GroptParams&&) = default;
-        GroptParams& operator=(GroptParams&&) = default;
-        GroptParams(const GroptParams&) = delete;
-        GroptParams& operator=(const GroptParams&) = delete;
+    // Move-only due to unique_ptr members
+    GroptParams(GroptParams &&) = default;
+    GroptParams &operator=(GroptParams &&) = default;
+    GroptParams(const GroptParams &) = delete;
+    GroptParams &operator=(const GroptParams &) = delete;
 
-        void vec_init_simple(int _N, int _Naxis, double first_val, double last_val);
-        void diff_init(double _dt, double _TE, double _T_90, double _T_180, double _T_readout);
-        void setvec_X0(int _N, int _Naxis, double *_X0, bool set_others);
-        void setvec_X0(const Eigen::VectorXd &_X0, int _Naxis, bool set_others);
+    void vec_init_simple(int _N, int _Naxis, double first_val, double last_val);
+    void diff_init(double _dt, double _TE, double _T_90, double _T_180, double _T_readout);
+    void setvec_X0(const Eigen::VectorXd &_X0, int _Naxis, bool set_others);
 
-        void vec_reduce_simple(int N_reduce);
+    void vec_reduce_simple(int N_reduce);
 
-        void prepare();
+    void prepare();
 
-        void set_ils_solver(std::string ils_method);
+    void set_ils_solver(std::string ils_method);
 
-        void add_gmax(double gmax, bool rot_variant, double weight_mod);
-        void add_smax(double smax, bool rot_variant, double weight_mod);
-        void add_moment(double order, double target, double tol0, std::string units,
-                        int moment_axis, int start_idx0, int stop_idx0, int ref_idx0, double weight_mod);
-        void add_SAFE(double stim_thresh,
-                      double *tau1, double *tau2, double *tau3,
-                      double *a1, double *a2, double *a3,
-                      double *stim_limit, double *g_scale,
-                      int new_first_axis, bool demo_params,
+    void add_gmax(double gmax, bool rot_variant, double weight_mod);
+    void add_smax(double smax, bool rot_variant, double weight_mod);
+    void add_concomitant(bool rot_variant, double weight_mod);
+    void add_moment(double order, double target, double tol0, std::string units, int moment_axis, int start_idx0,
+                    int stop_idx0, int ref_idx0, double weight_mod);
+
+    // TODO clean up all of these, they are leftover from the nanobind conversion
+    void add_SAFE(double stim_thresh, double *tau1, double *tau2, double *tau3, double *a1, double *a2, double *a3,
+                  double *stim_limit, double *g_scale, int new_first_axis, bool demo_params, double weight_mod);
+    // Eigen overload: demo params (no arrays needed)
+    void add_SAFE(double stim_thresh, int new_first_axis, double weight_mod);
+    // Eigen overload: custom params
+    void add_SAFE(double stim_thresh, const Eigen::VectorXd &tau1, const Eigen::VectorXd &tau2,
+                  const Eigen::VectorXd &tau3, const Eigen::VectorXd &a1, const Eigen::VectorXd &a2,
+                  const Eigen::VectorXd &a3, const Eigen::VectorXd &stim_limit, const Eigen::VectorXd &g_scale,
+                  int new_first_axis, double weight_mod);
+
+    void add_SAFE_vec(int N_vec, double *stim_thresh_vec, double *tau1, double *tau2, double *tau3, double *a1,
+                      double *a2, double *a3, double *stim_limit, double *g_scale, int new_first_axis, bool demo_params,
                       double weight_mod);
-        // Eigen overload: demo params (no arrays needed)
-        void add_SAFE(double stim_thresh, int new_first_axis, double weight_mod);
-        // Eigen overload: custom params
-        void add_SAFE(double stim_thresh,
-                      const Eigen::VectorXd &tau1, const Eigen::VectorXd &tau2, const Eigen::VectorXd &tau3,
-                      const Eigen::VectorXd &a1, const Eigen::VectorXd &a2, const Eigen::VectorXd &a3,
-                      const Eigen::VectorXd &stim_limit, const Eigen::VectorXd &g_scale,
+    // Eigen overload: demo params
+    void add_SAFE_vec(const Eigen::VectorXd &stim_thresh_vec, int new_first_axis, double weight_mod);
+    // Eigen overload: custom params
+    void add_SAFE_vec(const Eigen::VectorXd &stim_thresh_vec, const Eigen::VectorXd &tau1, const Eigen::VectorXd &tau2,
+                      const Eigen::VectorXd &tau3, const Eigen::VectorXd &a1, const Eigen::VectorXd &a2,
+                      const Eigen::VectorXd &a3, const Eigen::VectorXd &stim_limit, const Eigen::VectorXd &g_scale,
                       int new_first_axis, double weight_mod);
 
-        void add_SAFE_vec(int N_vec, double *stim_thresh_vec,
-                      double *tau1, double *tau2, double *tau3,
-                      double *a1, double *a2, double *a3,
-                      double *stim_limit, double *g_scale,
-                      int new_first_axis, bool demo_params,
-                      double weight_mod);
-        // Eigen overload: demo params
-        void add_SAFE_vec(const Eigen::VectorXd &stim_thresh_vec, int new_first_axis, double weight_mod);
-        // Eigen overload: custom params
-        void add_SAFE_vec(const Eigen::VectorXd &stim_thresh_vec,
-                          const Eigen::VectorXd &tau1, const Eigen::VectorXd &tau2, const Eigen::VectorXd &tau3,
-                          const Eigen::VectorXd &a1, const Eigen::VectorXd &a2, const Eigen::VectorXd &a3,
-                          const Eigen::VectorXd &stim_limit, const Eigen::VectorXd &g_scale,
-                          int new_first_axis, double weight_mod);
+    void add_bvalue(double target, double tol, int start_idx0, int stop_idx0, double weight_mod, int mode,
+                    double max_scale);
+    void add_TV(double tv_lam, double weight_mod);
 
-        void add_bvalue(double target, double tol, int start_idx0, int stop_idx0,
-                        double weight_mod, int mode, double max_scale);
-        void add_TV(double tv_lam, double weight_mod);
+    void add_obj_identity(double weight_mod);
 
-        void add_obj_identity(double weight_mod);
+    void reset_op_weights();
 
-        void reset_op_weights();
+    void print_op_details();
 
-        double get_output_bvalue(const Eigen::VectorXd &X);
+    double get_output_bvalue(const Eigen::VectorXd &X);
 };
 
-Eigen::VectorXd linear_interpolate(const Eigen::VectorXd& in, int out_size);
+Eigen::VectorXd linear_interpolate(const Eigen::VectorXd &in, int out_size);
 
 } // namespace Gropt
-
 
 #endif

--- a/gropt/src/gropt_utils.cpp
+++ b/gropt/src/gropt_utils.cpp
@@ -8,31 +8,9 @@
 
 namespace Gropt {
 
-static Eigen::VectorXd get_SAFE_impl(const Eigen::VectorXd &G, int Naxis, double dt, bool true_safe, int new_first_axis,
-                                     bool demo_params, double *tau1, double *tau2, double *tau3, double *a1, double *a2,
-                                     double *a3, double *stim_limit, double *g_scale) {
+static Eigen::VectorXd get_SAFE_compute(const Eigen::VectorXd &G, int Naxis, double dt, Op_SAFE &opF) {
     int N = static_cast<int>(G.size()) / Naxis;
 
-    ProblemData pdata;
-    pdata.dt = dt;
-    pdata.N = N;
-    pdata.Naxis = Naxis;
-    pdata.inv_vec.setOnes(N * Naxis);
-    pdata.set_vals.setZero(N * Naxis);
-    pdata.set_vals.array() *= NAN;
-    pdata.set_vals(0) = 0.0;
-    pdata.set_vals(N - 1) = 0.0;
-    pdata.fixer.setOnes(N * Naxis);
-    pdata.fixer(0) = 0.0;
-    pdata.fixer(N - 1) = 0.0;
-
-    Op_SAFE opF(pdata, 1.0, 1.0);
-    if (demo_params) {
-        opF.safe_params.set_demo_params();
-    } else {
-        opF.safe_params.set_params(tau1, tau2, tau3, a1, a2, a3, stim_limit, g_scale);
-    }
-    opF.safe_params.swap_first_axes(new_first_axis);
     opF.init();
 
     Eigen::VectorXd temp;
@@ -56,20 +34,40 @@ static Eigen::VectorXd get_SAFE_impl(const Eigen::VectorXd &G, int Naxis, double
     return opF.x_temp;
 }
 
+static ProblemData make_safe_pdata(const Eigen::VectorXd &G, int Naxis, double dt) {
+    int N = static_cast<int>(G.size()) / Naxis;
+    ProblemData pdata;
+    pdata.dt = dt;
+    pdata.N = N;
+    pdata.Naxis = Naxis;
+    pdata.inv_vec.setOnes(N * Naxis);
+    pdata.set_vals.setZero(N * Naxis);
+    pdata.set_vals.array() *= NAN;
+    pdata.set_vals(0) = 0.0;
+    pdata.set_vals(N - 1) = 0.0;
+    pdata.fixer.setOnes(N * Naxis);
+    pdata.fixer(0) = 0.0;
+    pdata.fixer(N - 1) = 0.0;
+    return pdata;
+}
+
 Eigen::VectorXd get_SAFE_eigen(const Eigen::VectorXd &G, int Naxis, double dt, bool true_safe, int new_first_axis) {
-    return get_SAFE_impl(G, Naxis, dt, true_safe, new_first_axis, true, nullptr, nullptr, nullptr, nullptr, nullptr,
-                         nullptr, nullptr, nullptr);
+    ProblemData pdata = make_safe_pdata(G, Naxis, dt);
+    Op_SAFE opF(pdata, 1.0, 1.0);
+    opF.safe_params.set_demo_params();
+    opF.safe_params.swap_first_axes(new_first_axis);
+    return get_SAFE_compute(G, Naxis, dt, opF);
 }
 
 Eigen::VectorXd get_SAFE_eigen(const Eigen::VectorXd &G, int Naxis, double dt, bool true_safe, int new_first_axis,
                                const Eigen::VectorXd &tau1, const Eigen::VectorXd &tau2, const Eigen::VectorXd &tau3,
                                const Eigen::VectorXd &a1, const Eigen::VectorXd &a2, const Eigen::VectorXd &a3,
                                const Eigen::VectorXd &stim_limit, const Eigen::VectorXd &g_scale) {
-    return get_SAFE_impl(G, Naxis, dt, true_safe, new_first_axis, false, const_cast<double *>(tau1.data()),
-                         const_cast<double *>(tau2.data()), const_cast<double *>(tau3.data()),
-                         const_cast<double *>(a1.data()), const_cast<double *>(a2.data()),
-                         const_cast<double *>(a3.data()), const_cast<double *>(stim_limit.data()),
-                         const_cast<double *>(g_scale.data()));
+    ProblemData pdata = make_safe_pdata(G, Naxis, dt);
+    Op_SAFE opF(pdata, 1.0, 1.0);
+    opF.safe_params.set_params(tau1, tau2, tau3, a1, a2, a3, stim_limit, g_scale);
+    opF.safe_params.swap_first_axes(new_first_axis);
+    return get_SAFE_compute(G, Naxis, dt, opF);
 }
 
 void test_eigen_assertions(int test_type) {

--- a/gropt/src/gropt_utils.cpp
+++ b/gropt/src/gropt_utils.cpp
@@ -135,19 +135,29 @@ Eigen::VectorXd get_SAFE_eigen(const Eigen::VectorXd &G, int Naxis, double dt, b
 void test_eigen_assertions(int test_type) {
     switch (test_type) {
     case 1: {
+        spdlog::info("Starting test_eigen_assertions(1)...");
         Eigen::VectorXd v(3);
         double x = v(10); // out of bounds
+        spdlog::info("Finsihed test_eigen_assertions(1)  x = {}", x);
         break;
     }
     case 2: {
+        spdlog::info("Starting test_eigen_assertions(2)...");
         Eigen::VectorXd v(5);
-        if (!v.array().isNaN().any())
+        if (!v.array().isNaN().any()) {
+            spdlog::info("No NaN found");
             throw std::runtime_error("expected NaN initialization");
+        } else {
+            spdlog::info("NaN found");
+        }
+        spdlog::info("Finished test_eigen_assertions(2)  v[0] = {}", v[0]);
         break;
     }
     case 3: {
+        spdlog::info("Starting test_eigen_assertions(3)...");
         Eigen::VectorXd a(3), b(5);
         Eigen::VectorXd c = a + b; // size mismatch
+        spdlog::info("Finished test_eigen_assertions(3)  c[4] = {}", c[4]);
         break;
     }
     default:

--- a/gropt/src/gropt_utils.cpp
+++ b/gropt/src/gropt_utils.cpp
@@ -1,5 +1,5 @@
-#include <cstdlib>
 #include "spdlog/spdlog.h"
+#include <cstdlib>
 
 #include "gropt_utils.hpp"
 
@@ -8,18 +8,14 @@
 
 namespace Gropt {
 
-void get_SAFE(int N, int Naxis, double dt, double *G_in,
-              bool true_safe, int new_first_axis, bool demo_params,
-              double *tau1, double *tau2, double *tau3,
-              double *a1, double *a2, double *a3,
-              double *stim_limit, double *g_scale,
-              double **out, int &out_size)
-{
+void get_SAFE(int N, int Naxis, double dt, double *G_in, bool true_safe, int new_first_axis, bool demo_params,
+              double *tau1, double *tau2, double *tau3, double *a1, double *a2, double *a3, double *stim_limit,
+              double *g_scale, double **out, int &out_size) {
     spdlog::trace("get_SAFE(): start");
 
     Eigen::VectorXd G;
     G.setZero(N);
-    for (int i=0; i<N; i++) {
+    for (int i = 0; i < N; i++) {
         G(i) = G_in[i];
     }
 
@@ -33,10 +29,10 @@ void get_SAFE(int N, int Naxis, double dt, double *G_in,
     pdata.set_vals.setZero(N * Naxis);
     pdata.set_vals.array() *= NAN;
     pdata.set_vals(0) = 0.0;
-    pdata.set_vals(N-1) = 0.0;
+    pdata.set_vals(N - 1) = 0.0;
     pdata.fixer.setOnes(N * Naxis);
     pdata.fixer(0) = 0.0;
-    pdata.fixer(N-1) = 0.0;
+    pdata.fixer(N - 1) = 0.0;
 
     spdlog::trace("get_SAFE(): finished pdata");
 
@@ -62,28 +58,24 @@ void get_SAFE(int N, int Naxis, double dt, double *G_in,
     opF.x_temp.setZero();
     for (int j = 0; j < Naxis; j++) {
         for (int i = 0; i < N; i++) {
-            opF.x_temp(j*N+i) = temp(j*3*N+i) + temp(j*3*N+i+N) + temp(j*3*N+i+2*N);
+            opF.x_temp(j * N + i) = temp(j * 3 * N + i) + temp(j * 3 * N + i + N) + temp(j * 3 * N + i + 2 * N);
         }
     }
 
     spdlog::trace("get_SAFE(): finished combine");
 
     out_size = opF.x_temp.size();
-    *out = (double*)std::malloc(out_size * sizeof(double));
+    *out = (double *)std::malloc(out_size * sizeof(double));
     for (int i = 0; i < out_size; i++) {
         (*out)[i] = opF.x_temp(i);
     }
 
     spdlog::trace("get_SAFE(): finished copying out");
-
 }
 
-static Eigen::VectorXd get_SAFE_impl(const Eigen::VectorXd &G, int Naxis, double dt,
-                                     bool true_safe, int new_first_axis, bool demo_params,
-                                     double *tau1, double *tau2, double *tau3,
-                                     double *a1, double *a2, double *a3,
-                                     double *stim_limit, double *g_scale)
-{
+static Eigen::VectorXd get_SAFE_impl(const Eigen::VectorXd &G, int Naxis, double dt, bool true_safe, int new_first_axis,
+                                     bool demo_params, double *tau1, double *tau2, double *tau3, double *a1, double *a2,
+                                     double *a3, double *stim_limit, double *g_scale) {
     int N = static_cast<int>(G.size()) / Naxis;
 
     ProblemData pdata;
@@ -94,10 +86,10 @@ static Eigen::VectorXd get_SAFE_impl(const Eigen::VectorXd &G, int Naxis, double
     pdata.set_vals.setZero(N * Naxis);
     pdata.set_vals.array() *= NAN;
     pdata.set_vals(0) = 0.0;
-    pdata.set_vals(N-1) = 0.0;
+    pdata.set_vals(N - 1) = 0.0;
     pdata.fixer.setOnes(N * Naxis);
     pdata.fixer(0) = 0.0;
-    pdata.fixer(N-1) = 0.0;
+    pdata.fixer(N - 1) = 0.0;
 
     Op_SAFE opF(pdata, 1.0, 1.0);
     if (demo_params) {
@@ -117,30 +109,50 @@ static Eigen::VectorXd get_SAFE_impl(const Eigen::VectorXd &G, int Naxis, double
     opF.x_temp.setZero();
     for (int j = 0; j < Naxis; j++) {
         for (int i = 0; i < N; i++) {
-            opF.x_temp(j*N+i) = temp(j*3*N+i) + temp(j*3*N+i+N) + temp(j*3*N+i+2*N);
+            opF.x_temp(j * N + i) = temp(j * 3 * N + i) + temp(j * 3 * N + i + N) + temp(j * 3 * N + i + 2 * N);
         }
     }
 
     return opF.x_temp;
 }
 
-Eigen::VectorXd get_SAFE_eigen(const Eigen::VectorXd &G, int Naxis, double dt,
-                               bool true_safe, int new_first_axis)
-{
-    return get_SAFE_impl(G, Naxis, dt, true_safe, new_first_axis, true,
-                         nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
+Eigen::VectorXd get_SAFE_eigen(const Eigen::VectorXd &G, int Naxis, double dt, bool true_safe, int new_first_axis) {
+    return get_SAFE_impl(G, Naxis, dt, true_safe, new_first_axis, true, nullptr, nullptr, nullptr, nullptr, nullptr,
+                         nullptr, nullptr, nullptr);
 }
 
-Eigen::VectorXd get_SAFE_eigen(const Eigen::VectorXd &G, int Naxis, double dt,
-                               bool true_safe, int new_first_axis,
+Eigen::VectorXd get_SAFE_eigen(const Eigen::VectorXd &G, int Naxis, double dt, bool true_safe, int new_first_axis,
                                const Eigen::VectorXd &tau1, const Eigen::VectorXd &tau2, const Eigen::VectorXd &tau3,
                                const Eigen::VectorXd &a1, const Eigen::VectorXd &a2, const Eigen::VectorXd &a3,
-                               const Eigen::VectorXd &stim_limit, const Eigen::VectorXd &g_scale)
-{
-    return get_SAFE_impl(G, Naxis, dt, true_safe, new_first_axis, false,
-                         const_cast<double*>(tau1.data()), const_cast<double*>(tau2.data()), const_cast<double*>(tau3.data()),
-                         const_cast<double*>(a1.data()), const_cast<double*>(a2.data()), const_cast<double*>(a3.data()),
-                         const_cast<double*>(stim_limit.data()), const_cast<double*>(g_scale.data()));
+                               const Eigen::VectorXd &stim_limit, const Eigen::VectorXd &g_scale) {
+    return get_SAFE_impl(G, Naxis, dt, true_safe, new_first_axis, false, const_cast<double *>(tau1.data()),
+                         const_cast<double *>(tau2.data()), const_cast<double *>(tau3.data()),
+                         const_cast<double *>(a1.data()), const_cast<double *>(a2.data()),
+                         const_cast<double *>(a3.data()), const_cast<double *>(stim_limit.data()),
+                         const_cast<double *>(g_scale.data()));
+}
+
+void test_eigen_assertions(int test_type) {
+    switch (test_type) {
+    case 1: {
+        Eigen::VectorXd v(3);
+        double x = v(10); // out of bounds
+        break;
+    }
+    case 2: {
+        Eigen::VectorXd v(5);
+        if (!v.array().isNaN().any())
+            throw std::runtime_error("expected NaN initialization");
+        break;
+    }
+    case 3: {
+        Eigen::VectorXd a(3), b(5);
+        Eigen::VectorXd c = a + b; // size mismatch
+        break;
+    }
+    default:
+        throw std::invalid_argument("unknown test type");
+    }
 }
 
 } // namespace Gropt

--- a/gropt/src/gropt_utils.cpp
+++ b/gropt/src/gropt_utils.cpp
@@ -8,71 +8,6 @@
 
 namespace Gropt {
 
-void get_SAFE(int N, int Naxis, double dt, double *G_in, bool true_safe, int new_first_axis, bool demo_params,
-              double *tau1, double *tau2, double *tau3, double *a1, double *a2, double *a3, double *stim_limit,
-              double *g_scale, double **out, int &out_size) {
-    spdlog::trace("get_SAFE(): start");
-
-    Eigen::VectorXd G;
-    G.setZero(N);
-    for (int i = 0; i < N; i++) {
-        G(i) = G_in[i];
-    }
-
-    spdlog::trace("get_SAFE(): copied G");
-
-    ProblemData pdata;
-    pdata.dt = dt;
-    pdata.N = N;
-    pdata.Naxis = Naxis;
-    pdata.inv_vec.setOnes(N * Naxis);
-    pdata.set_vals.setZero(N * Naxis);
-    pdata.set_vals.array() *= NAN;
-    pdata.set_vals(0) = 0.0;
-    pdata.set_vals(N - 1) = 0.0;
-    pdata.fixer.setOnes(N * Naxis);
-    pdata.fixer(0) = 0.0;
-    pdata.fixer(N - 1) = 0.0;
-
-    spdlog::trace("get_SAFE(): finished pdata");
-
-    Op_SAFE opF(pdata, 1.0, 1.0);
-    if (demo_params) {
-        opF.safe_params.set_demo_params();
-    } else {
-        opF.safe_params.set_params(tau1, tau2, tau3, a1, a2, a3, stim_limit, g_scale);
-    }
-    opF.safe_params.swap_first_axes(new_first_axis);
-    opF.init();
-
-    spdlog::trace("get_SAFE(): finished Op_SAFE");
-
-    Eigen::VectorXd temp;
-    temp.setZero(opF.Ax_size);
-    opF.forward(G, temp);
-
-    opF.check(temp);
-
-    spdlog::trace("get_SAFE(): finished forward");
-
-    opF.x_temp.setZero();
-    for (int j = 0; j < Naxis; j++) {
-        for (int i = 0; i < N; i++) {
-            opF.x_temp(j * N + i) = temp(j * 3 * N + i) + temp(j * 3 * N + i + N) + temp(j * 3 * N + i + 2 * N);
-        }
-    }
-
-    spdlog::trace("get_SAFE(): finished combine");
-
-    out_size = opF.x_temp.size();
-    *out = (double *)std::malloc(out_size * sizeof(double));
-    for (int i = 0; i < out_size; i++) {
-        (*out)[i] = opF.x_temp(i);
-    }
-
-    spdlog::trace("get_SAFE(): finished copying out");
-}
-
 static Eigen::VectorXd get_SAFE_impl(const Eigen::VectorXd &G, int Naxis, double dt, bool true_safe, int new_first_axis,
                                      bool demo_params, double *tau1, double *tau2, double *tau3, double *a1, double *a2,
                                      double *a3, double *stim_limit, double *g_scale) {
@@ -109,7 +44,12 @@ static Eigen::VectorXd get_SAFE_impl(const Eigen::VectorXd &G, int Naxis, double
     opF.x_temp.setZero();
     for (int j = 0; j < Naxis; j++) {
         for (int i = 0; i < N; i++) {
-            opF.x_temp(j * N + i) = temp(j * 3 * N + i) + temp(j * 3 * N + i + N) + temp(j * 3 * N + i + 2 * N);
+            if (opF.n_terms == 3) {
+                opF.x_temp(j * N + i) = temp(j * opF.n_terms * N + i) + temp(j * opF.n_terms * N + i + N) +
+                                        temp(j * opF.n_terms * N + i + 2 * N);
+            } else if (opF.n_terms == 2) {
+                opF.x_temp(j * N + i) = temp(j * opF.n_terms * N + i) + temp(j * opF.n_terms * N + i + N);
+            }
         }
     }
 

--- a/gropt/src/gropt_utils.hpp
+++ b/gropt/src/gropt_utils.hpp
@@ -16,10 +16,6 @@
 
 namespace Gropt {
 
-void get_SAFE(int N, int Naxis, double dt, double *G_in, bool true_safe, int new_first_axis, bool demo_params,
-              double *tau1, double *tau2, double *tau3, double *a1, double *a2, double *a3, double *stim_limit,
-              double *g_scale, double **out, int &out_size);
-
 // Eigen overload: demo params
 Eigen::VectorXd get_SAFE_eigen(const Eigen::VectorXd &G, int Naxis, double dt, bool true_safe, int new_first_axis);
 // Eigen overload: custom params

--- a/gropt/src/gropt_utils.hpp
+++ b/gropt/src/gropt_utils.hpp
@@ -4,35 +4,32 @@
 /**
  * In general this is just a place for random usages of the GrOpt
  * operators for applications that aren't actual optimization.
- * 
- * i.e. GIRF respone calculation or spectral calcs, or getting a 
+ *
+ * i.e. GIRF respone calculation or spectral calcs, or getting a
  * PNS curve for a waveform
  */
 
-#include <iostream> 
+#include "Eigen/Dense"
+#include <iostream>
 #include <string>
 #include <vector>
-#include "Eigen/Dense"
 
 namespace Gropt {
-    
-void get_SAFE(int N, int Naxis, double dt, double *G_in,
-              bool true_safe, int new_first_axis, bool demo_params,
-              double *tau1, double *tau2, double *tau3,
-              double *a1, double *a2, double *a3,
-              double *stim_limit, double *g_scale,
-              double **out, int &out_size);
+
+void get_SAFE(int N, int Naxis, double dt, double *G_in, bool true_safe, int new_first_axis, bool demo_params,
+              double *tau1, double *tau2, double *tau3, double *a1, double *a2, double *a3, double *stim_limit,
+              double *g_scale, double **out, int &out_size);
 
 // Eigen overload: demo params
-Eigen::VectorXd get_SAFE_eigen(const Eigen::VectorXd &G, int Naxis, double dt,
-                               bool true_safe, int new_first_axis);
+Eigen::VectorXd get_SAFE_eigen(const Eigen::VectorXd &G, int Naxis, double dt, bool true_safe, int new_first_axis);
 // Eigen overload: custom params
-Eigen::VectorXd get_SAFE_eigen(const Eigen::VectorXd &G, int Naxis, double dt,
-                               bool true_safe, int new_first_axis,
+Eigen::VectorXd get_SAFE_eigen(const Eigen::VectorXd &G, int Naxis, double dt, bool true_safe, int new_first_axis,
                                const Eigen::VectorXd &tau1, const Eigen::VectorXd &tau2, const Eigen::VectorXd &tau3,
                                const Eigen::VectorXd &a1, const Eigen::VectorXd &a2, const Eigen::VectorXd &a3,
                                const Eigen::VectorXd &stim_limit, const Eigen::VectorXd &g_scale);
 
-}  // close "namespace Gropt"
+void test_eigen_assertions(int test_type);
+
+} // namespace Gropt
 
 #endif

--- a/gropt/src/op_bvalue.cpp
+++ b/gropt/src/op_bvalue.cpp
@@ -4,10 +4,9 @@
 
 namespace Gropt {
 
-Op_BValue::Op_BValue(const ProblemData &_pdata, double _bval_target, double _bval_tol0,
-                     int _start_idx0, int _stop_idx0, double _weight_mod, BVALUE_MODE _mode, double _max_scale)
-    : Operator(_pdata)
-{
+Op_BValue::Op_BValue(const ProblemData &_pdata, double _bval_target, double _bval_tol0, int _start_idx0, int _stop_idx0,
+                     double _weight_mod, BVALUE_MODE _mode, double _max_scale)
+    : Operator(_pdata) {
     name = "b-value";
 
     bval_target = _bval_target;
@@ -25,16 +24,15 @@ Op_BValue::Op_BValue(const ProblemData &_pdata, double _bval_target, double _bva
     max_scale = _max_scale;
 }
 
-void Op_BValue::init()
-{
+void Op_BValue::init() {
     spdlog::trace("Op_BValue::init  N = {}", pdata->N);
 
     target = bval_target;
     tol0 = bval_tol0;
-    tol = (1.0-cushion) * tol0;
+    tol = (1.0 - cushion) * tol0;
 
-    GAMMA = 267.5221900e6;  // rad/S/T
-    MAT_SCALE = pow((GAMMA / 1000.0 * pdata->dt), 2.0) * pdata->dt;  // 1/1000 is for m->mm in b-value
+    GAMMA = 267.5221900e6;                                          // rad/S/T
+    MAT_SCALE = pow((GAMMA / 1000.0 * pdata->dt), 2.0) * pdata->dt; // 1/1000 is for m->mm in b-value
 
     // If start and stop indices are not set, constraint covers the whole axis
     if (start_idx <= 0) {
@@ -50,7 +48,7 @@ void Op_BValue::init()
     }
 
     int Nnorm = i_stop - i_start;
-    spec_norm2 = (Nnorm*Nnorm + Nnorm)/2.0 * MAT_SCALE;
+    spec_norm2 = (Nnorm * Nnorm + Nnorm) / 2.0 * MAT_SCALE;
     spec_norm = sqrt(spec_norm2);
 
     Ax_size = pdata->Naxis * pdata->N;
@@ -63,11 +61,10 @@ void Op_BValue::init()
     Operator::init();
 }
 
-void Op_BValue::forward(Eigen::VectorXd &X, Eigen::VectorXd &out)
-{
+void Op_BValue::forward(Eigen::VectorXd &X, Eigen::VectorXd &out) {
     out.setZero();
     for (int j = 0; j < Naxis; j++) {
-        int jN = j*N;
+        int jN = j * N;
         double gt = 0;
         for (int i = i_start; i < i_stop; i++) {
             gt += X(jN + i) * pdata->inv_vec(jN + i);
@@ -76,13 +73,12 @@ void Op_BValue::forward(Eigen::VectorXd &X, Eigen::VectorXd &out)
     }
 }
 
-void Op_BValue::transpose(Eigen::VectorXd &X, Eigen::VectorXd &out)
-{
+void Op_BValue::transpose(Eigen::VectorXd &X, Eigen::VectorXd &out) {
     out.setZero();
     for (int j = 0; j < Naxis; j++) {
-        int jN = j*N;
+        int jN = j * N;
         double gt = 0;
-        for (int i = i_stop-1; i >= i_start; i--) {
+        for (int i = i_stop - 1; i >= i_start; i--) {
             gt += X(jN + i) * sqrt(MAT_SCALE);
             out(jN + i) = gt * pdata->inv_vec(jN + i);
         }
@@ -90,53 +86,60 @@ void Op_BValue::transpose(Eigen::VectorXd &X, Eigen::VectorXd &out)
 }
 
 // TODO: This seems all wrong for three axis case, need to fix
-void Op_BValue::prox(Eigen::VectorXd &X)
-{
+void Op_BValue::prox(Eigen::VectorXd &X) {
     spdlog::trace("Starting Op_BValue::prox");
 
-    for (int j = 0; j < Naxis; j++) {
-        double xnorm = X.segment(j*N, N).norm();
+    if (do_equil) {
+        X.array() /= eq_rows.array();
+    }
 
+    for (int j = 0; j < Naxis; j++) {
+        double xnorm = X.segment(j * N, N).norm();
 
         if (mode == BVALUE_MODE_MINVAL) {
             double min_val = sqrt(target);
 
             if (xnorm < min_val) {
-                X.segment(j*N, N) *= (min_val/xnorm);
+                X.segment(j * N, N) *= (min_val / xnorm);
             }
         } else if (mode == BVALUE_MODE_MINVALMAX) {
             double min_val = sqrt(target);
 
             if (xnorm < min_val) {
-                X.segment(j*N, N) *= (max_scale*min_val/xnorm);
+                X.segment(j * N, N) *= (max_scale * min_val / xnorm);
             } else {
-                X.segment(j*N, N) *= max_scale;
+                X.segment(j * N, N) *= max_scale;
             }
         } else if (mode == BVALUE_MODE_SETVAL) {
             double min_val = sqrt(target - tol);
             double max_val = sqrt(target + tol);
 
             if (xnorm < min_val) {
-                X.segment(j*N, N) *= (min_val/xnorm);
+                X.segment(j * N, N) *= (min_val / xnorm);
             } else if (xnorm > max_val) {
-                X.segment(j*N, N) *= (max_val/xnorm);
+                X.segment(j * N, N) *= (max_val / xnorm);
             }
         } else {
             spdlog::error("Unknown BVALUE_MODE in Op_BValue::prox");
         }
+    }
 
+    if (do_equil) {
+        X.array() *= eq_rows.array();
     }
 
     spdlog::trace("Finished Op_BValue::prox");
 }
 
-
-void Op_BValue::check(Eigen::VectorXd &X)
-{
+void Op_BValue::check(Eigen::VectorXd &X) {
     int is_feas = 1;
 
+    if (do_equil) {
+        X.array() /= eq_rows.array();
+    }
+
     for (int j = 0; j < Naxis; j++) {
-        double bval_t = (X.segment(j*N, N)).squaredNorm();
+        double bval_t = (X.segment(j * N, N)).squaredNorm();
 
         if (mode == BVALUE_MODE_MINVAL || mode == BVALUE_MODE_MINVALMAX) {
             if (bval_t < target) {
@@ -150,18 +153,20 @@ void Op_BValue::check(Eigen::VectorXd &X)
         } else {
             spdlog::error("Unknown BVALUE_MODE in Op_BValue::check");
         }
+    }
 
+    if (do_equil) {
+        X.array() *= eq_rows.array();
     }
 
     hist_feas.push_back(is_feas);
 }
 
-double Op_BValue::get_bvalue(Eigen::VectorXd &X)
-{
+double Op_BValue::get_bvalue(Eigen::VectorXd &X) {
     Ax_temp.setZero();
     forward_op(X, Ax_temp);
 
     return Ax_temp.squaredNorm();
 }
 
-}  // close "namespace Gropt"
+} // namespace Gropt

--- a/gropt/src/op_bvalue.cpp
+++ b/gropt/src/op_bvalue.cpp
@@ -48,7 +48,8 @@ void Op_BValue::init() {
     }
 
     int Nnorm = i_stop - i_start;
-    spec_norm2 = (Nnorm * Nnorm + Nnorm) / 2.0 * MAT_SCALE;
+    spec_norm2 = (Nnorm * Nnorm + Nnorm) / 2.0 * MAT_SCALE * 0.1175 * 4;
+    // spec_norm2 = spec_norm2 * spec_norm2;
     spec_norm = sqrt(spec_norm2);
 
     Ax_size = pdata->Naxis * pdata->N;
@@ -92,6 +93,7 @@ void Op_BValue::prox(Eigen::VectorXd &X) {
     if (do_equil) {
         X.array() /= eq_rows.array();
     }
+    X.array() *= spec_norm;
 
     for (int j = 0; j < Naxis; j++) {
         double xnorm = X.segment(j * N, N).norm();
@@ -127,6 +129,7 @@ void Op_BValue::prox(Eigen::VectorXd &X) {
     if (do_equil) {
         X.array() *= eq_rows.array();
     }
+    X.array() /= spec_norm;
 
     spdlog::trace("Finished Op_BValue::prox");
 }
@@ -137,6 +140,7 @@ void Op_BValue::check(Eigen::VectorXd &X) {
     if (do_equil) {
         X.array() /= eq_rows.array();
     }
+    X.array() *= spec_norm;
 
     for (int j = 0; j < Naxis; j++) {
         double bval_t = (X.segment(j * N, N)).squaredNorm();
@@ -158,6 +162,7 @@ void Op_BValue::check(Eigen::VectorXd &X) {
     if (do_equil) {
         X.array() *= eq_rows.array();
     }
+    X.array() /= spec_norm;
 
     hist_feas.push_back(is_feas);
 }

--- a/gropt/src/op_concomitant.cpp
+++ b/gropt/src/op_concomitant.cpp
@@ -1,0 +1,128 @@
+#include "spdlog/spdlog.h"
+
+#include "op_gradient.hpp"
+
+namespace Gropt {
+
+Op_Gradient::Op_Gradient(const ProblemData &_pdata, double _gmax, bool _rot_variant, double _weight_mod)
+    : Operator(_pdata) {
+    name = "Gradient";
+    gmax = _gmax;
+    rot_variant = _rot_variant;
+    weight_mod = _weight_mod;
+}
+
+void Op_Gradient::init() {
+    spdlog::trace("Op_Gradient::init  N = {}", pdata->N);
+
+    target = 0;
+    tol0 = gmax;
+    tol = (1.0 - cushion) * tol0;
+
+    spec_norm2 = 1.0;
+    spec_norm = 1.0;
+
+    Ax_size = pdata->Naxis * pdata->N;
+
+    if (do_init_weights) {
+        obj_weight = 1.0;
+        obj_weight *= weight_mod;
+    }
+
+    Operator::init();
+}
+
+void Op_Gradient::forward(Eigen::VectorXd &X, Eigen::VectorXd &out) { out = X; }
+
+void Op_Gradient::transpose(Eigen::VectorXd &X, Eigen::VectorXd &out) { out = X; }
+
+void Op_Gradient::prox(Eigen::VectorXd &X) {
+    spdlog::trace("Starting Op_Gradient::prox");
+
+    if (do_equil) {
+        X.array() /= eq_rows.array();
+    }
+
+    if (rot_variant) {
+        for (int i = 0; i < X.size(); i++) {
+            double lower_bound = (target - tol);
+            double upper_bound = (target + tol);
+            X(i) = X(i) < lower_bound ? lower_bound : X(i);
+            X(i) = X(i) > upper_bound ? upper_bound : X(i);
+
+            // This is specific to the Op_Gradient operator
+            if (!isnan(pdata->set_vals(i))) {
+                X(i) = pdata->set_vals(i);
+            }
+        }
+    } else {
+        for (int i = 0; i < N; i++) {
+            double upper_bound = (target + tol);
+
+            double val = 0.0;
+            for (int i_ax = 0; i_ax < Naxis; i_ax++) {
+                val += X(i_ax * N + i) * X(i_ax * N + i);
+            }
+            val = sqrt(val);
+
+            if (val > upper_bound) {
+                for (int i_ax = 0; i_ax < Naxis; i_ax++) {
+                    X(i_ax * N + i) *= (upper_bound / val);
+                }
+            }
+        }
+
+        for (int i = 0; i < X.size(); i++) {
+            if (!isnan(pdata->set_vals(i))) {
+                X(i) = pdata->set_vals(i);
+            }
+        }
+    }
+
+    if (do_equil) {
+        X.array() *= eq_rows.array();
+    }
+
+    spdlog::trace("Finished Op_Gradient::prox");
+}
+
+void Op_Gradient::check(Eigen::VectorXd &X) {
+    int is_feas = 1;
+
+    if (do_equil) {
+        X.array() /= eq_rows.array();
+    }
+
+    if (rot_variant) {
+        for (int i = 0; i < X.size(); i++) {
+            double lower_bound = (target - tol0);
+            double upper_bound = (target + tol0);
+
+            if ((X(i) < lower_bound) || (X(i) > upper_bound) && isnan(pdata->set_vals(i))) {
+                is_feas = 0;
+            }
+        }
+    } else {
+        for (int i = 0; i < N; i++) {
+            double upper_bound = (target + tol0);
+
+            double val = 0.0;
+            for (int i_ax = 0; i_ax < Naxis; i_ax++) {
+                val += X(i_ax * N + i) * X(i_ax * N + i);
+            }
+            val = sqrt(val);
+
+            if ((val > upper_bound) && isnan(pdata->set_vals(i))) {
+                is_feas = 0;
+            }
+        }
+    }
+
+    if (do_equil) {
+        X.array() *= eq_rows.array();
+    }
+
+    hist_feas.push_back(is_feas);
+}
+
+} // namespace Gropt

--- a/gropt/src/op_concomitant.cpp
+++ b/gropt/src/op_concomitant.cpp
@@ -1,22 +1,20 @@
 #include "spdlog/spdlog.h"
 
-#include "op_gradient.hpp"
+#include "op_concomitant.hpp"
 
 namespace Gropt {
 
-Op_Gradient::Op_Gradient(const ProblemData &_pdata, double _gmax, bool _rot_variant, double _weight_mod)
-    : Operator(_pdata) {
-    name = "Gradient";
-    gmax = _gmax;
+Op_Concomitant::Op_Concomitant(const ProblemData &_pdata, bool _rot_variant, double _weight_mod) : Operator(_pdata) {
+    name = "Concomitant";
     rot_variant = _rot_variant;
     weight_mod = _weight_mod;
 }
 
-void Op_Gradient::init() {
-    spdlog::trace("Op_Gradient::init  N = {}", pdata->N);
+void Op_Concomitant::init() {
+    spdlog::trace("Op_Concomitant::init  N = {}", pdata->N);
 
     target = 0;
-    tol0 = gmax;
+    tol0 = 1.0;
     tol = (1.0 - cushion) * tol0;
 
     spec_norm2 = 1.0;
@@ -32,49 +30,40 @@ void Op_Gradient::init() {
     Operator::init();
 }
 
-void Op_Gradient::forward(Eigen::VectorXd &X, Eigen::VectorXd &out) { out = X; }
+void Op_Concomitant::forward(Eigen::VectorXd &X, Eigen::VectorXd &out) { out = X; }
 
-void Op_Gradient::transpose(Eigen::VectorXd &X, Eigen::VectorXd &out) { out = X; }
+void Op_Concomitant::transpose(Eigen::VectorXd &X, Eigen::VectorXd &out) { out = X; }
 
-void Op_Gradient::prox(Eigen::VectorXd &X) {
-    spdlog::trace("Starting Op_Gradient::prox");
+void Op_Concomitant::prox(Eigen::VectorXd &X) {
+    spdlog::trace("Starting Op_Concomitant::prox");
 
     if (do_equil) {
         X.array() /= eq_rows.array();
     }
 
-    if (rot_variant) {
-        for (int i = 0; i < X.size(); i++) {
-            double lower_bound = (target - tol);
-            double upper_bound = (target + tol);
-            X(i) = X(i) < lower_bound ? lower_bound : X(i);
-            X(i) = X(i) > upper_bound ? upper_bound : X(i);
+    double pos = 0.0;
+    double neg = 0.0;
 
-            // This is specific to the Op_Gradient operator
-            if (!isnan(pdata->set_vals(i))) {
-                X(i) = pdata->set_vals(i);
+    for (int i = 0; i < X.size(); i++) {
+        if (pdata->inv_vec(i) > 0) {
+            pos += X(i) * X(i);
+        } else if (pdata->inv_vec(i) < 0) {
+            neg += X(i) * X(i);
+        }
+    }
+
+    if (pos > neg) {
+        double scale = 1.0 / sqrt(pos / neg);
+        for (int i = 0; i < X.size(); i++) {
+            if (pdata->inv_vec(i) > 0) {
+                X(i) *= scale;
             }
         }
-    } else {
-        for (int i = 0; i < N; i++) {
-            double upper_bound = (target + tol);
-
-            double val = 0.0;
-            for (int i_ax = 0; i_ax < Naxis; i_ax++) {
-                val += X(i_ax * N + i) * X(i_ax * N + i);
-            }
-            val = sqrt(val);
-
-            if (val > upper_bound) {
-                for (int i_ax = 0; i_ax < Naxis; i_ax++) {
-                    X(i_ax * N + i) *= (upper_bound / val);
-                }
-            }
-        }
-
+    } else if (neg > pos) {
+        double scale = 1.0 / sqrt(neg / pos);
         for (int i = 0; i < X.size(); i++) {
-            if (!isnan(pdata->set_vals(i))) {
-                X(i) = pdata->set_vals(i);
+            if (pdata->inv_vec(i) < 0) {
+                X(i) *= scale;
             }
         }
     }
@@ -83,39 +72,29 @@ void Op_Gradient::prox(Eigen::VectorXd &X) {
         X.array() *= eq_rows.array();
     }
 
-    spdlog::trace("Finished Op_Gradient::prox");
+    spdlog::trace("Finished Op_Concomitant::prox");
 }
 
-void Op_Gradient::check(Eigen::VectorXd &X) {
+void Op_Concomitant::check(Eigen::VectorXd &X) {
     int is_feas = 1;
 
     if (do_equil) {
         X.array() /= eq_rows.array();
     }
 
-    if (rot_variant) {
-        for (int i = 0; i < X.size(); i++) {
-            double lower_bound = (target - tol0);
-            double upper_bound = (target + tol0);
+    double pos = 0.0;
+    double neg = 0.0;
 
-            if ((X(i) < lower_bound) || (X(i) > upper_bound) && isnan(pdata->set_vals(i))) {
-                is_feas = 0;
-            }
+    for (int i = 0; i < X.size(); i++) {
+        if (pdata->inv_vec(i) > 0) {
+            pos += X(i) * X(i);
+        } else if (pdata->inv_vec(i) < 0) {
+            neg += X(i) * X(i);
         }
-    } else {
-        for (int i = 0; i < N; i++) {
-            double upper_bound = (target + tol0);
+    }
 
-            double val = 0.0;
-            for (int i_ax = 0; i_ax < Naxis; i_ax++) {
-                val += X(i_ax * N + i) * X(i_ax * N + i);
-            }
-            val = sqrt(val);
-
-            if ((val > upper_bound) && isnan(pdata->set_vals(i))) {
-                is_feas = 0;
-            }
-        }
+    if (abs(1.0 - (pos / neg)) > 0.1) {
+        is_feas = 0;
     }
 
     if (do_equil) {

--- a/gropt/src/op_concomitant.hpp
+++ b/gropt/src/op_concomitant.hpp
@@ -1,0 +1,36 @@
+#ifndef OP_CONCOMITANT_H
+#define OP_CONCOMITANT_H
+
+/**
+ * Constraint on gradient amplitude.  Supports the 'rot_variant' variable
+ * to decide if gmax operates per axis or on the gradient magnitude
+ *
+ * Checks 'set_vals' and forces those values if they are not NaN
+ */
+
+#include "Eigen/Dense"
+#include <iostream>
+#include <math.h>
+#include <string>
+
+#include "op_main.hpp"
+
+namespace Gropt {
+
+class Op_Concomitant : public Operator {
+  protected:
+    double gmax;
+
+  public:
+    Op_Concomitant(const ProblemData &_pdata, double _gmax, bool _rot_variant, double _weight_mod);
+    virtual void init();
+
+    virtual void forward(Eigen::VectorXd &X, Eigen::VectorXd &out);
+    virtual void transpose(Eigen::VectorXd &X, Eigen::VectorXd &out);
+    virtual void prox(Eigen::VectorXd &X);
+    virtual void check(Eigen::VectorXd &X);
+};
+
+} // namespace Gropt
+
+#endif

--- a/gropt/src/op_concomitant.hpp
+++ b/gropt/src/op_concomitant.hpp
@@ -18,11 +18,9 @@
 namespace Gropt {
 
 class Op_Concomitant : public Operator {
-  protected:
-    double gmax;
 
   public:
-    Op_Concomitant(const ProblemData &_pdata, double _gmax, bool _rot_variant, double _weight_mod);
+    Op_Concomitant(const ProblemData &_pdata, bool _rot_variant, double _weight_mod);
     virtual void init();
 
     virtual void forward(Eigen::VectorXd &X, Eigen::VectorXd &out);

--- a/gropt/src/op_main.cpp
+++ b/gropt/src/op_main.cpp
@@ -23,6 +23,9 @@ void Operator::init() {
     x_temp.setZero(Ntot);
     x_temp_obj.setZero(Ntot);
     Ax_temp.setZero(Ax_size);
+
+    eq_rows.setOnes(Ax_size);
+    eq_cols.setOnes(Ntot);
 }
 
 void Operator::forward(Eigen::VectorXd &X, Eigen::VectorXd &out) {

--- a/gropt/src/op_main.cpp
+++ b/gropt/src/op_main.cpp
@@ -46,6 +46,7 @@ void Operator::forward_op(Eigen::VectorXd &X, Eigen::VectorXd &out) {
 
     forward(x_temp, out);
 
+    out.array() /= spec_norm;
     if (do_equil) {
         out.array() *= eq_rows.array();
     }
@@ -63,7 +64,7 @@ void Operator::transpose_op(Eigen::VectorXd &X, Eigen::VectorXd &out, bool apply
     if (apply_fixer) {
         out.array() *= pdata->fixer.array();
     }
-    out.array() /= spec_norm2;
+    out.array() /= spec_norm;
 
     if (do_equil) {
         out.array() *= eq_cols.array();
@@ -133,6 +134,17 @@ void Operator::get_feas(Eigen::VectorXd &s) {
     r_feas = feas_temp.cwiseAbs().maxCoeff() / (s.cwiseAbs().maxCoeff() + 1.0e-32);
 
     hist_r_feas.push_back(r_feas);
+}
+
+void Operator::print_details() {
+    spdlog::info("========== Operator name: {:^16} ==========", name);
+    spdlog::info("N: {}, Naxis: {}, Ntot: {}, dt: {}", N, Naxis, Ntot, dt);
+    spdlog::info("target: {:.2e}, tol0: {:.2e}, tol: {:.2e}, cushion: {:.2e}", target, tol0, tol, cushion);
+    spdlog::info("Ax_size: {}", Ax_size);
+    spdlog::info("spec_norm: {:.2e}, spec_norm2: {:.2e}", spec_norm, spec_norm2);
+    spdlog::info("obj_weight: {:.2e}, weight_mod: {:.2e}", obj_weight, weight_mod);
+    spdlog::info("do_equil: {}, rot_variant: {}, do_init_weights: {}", do_equil, rot_variant, do_init_weights);
+    spdlog::default_logger()->flush();
 }
 
 } // namespace Gropt

--- a/gropt/src/op_main.hpp
+++ b/gropt/src/op_main.hpp
@@ -79,6 +79,7 @@ class Operator // This is the main parent class for every operator in GrOpt
     virtual void add_Atb(Eigen::VectorXd &b, const WorkspaceSolver &ws);
     void add_AtAx(Eigen::VectorXd &x, Eigen::VectorXd &out, const WorkspaceSolver &ws);
     virtual void add_obj(Eigen::VectorXd &x, Eigen::VectorXd &out);
+    void print_details();
 };
 
 } // namespace Gropt

--- a/gropt/src/op_moment.cpp
+++ b/gropt/src/op_moment.cpp
@@ -70,8 +70,6 @@ void Op_Moment::init() {
         A(0, j) = val * pdata->inv_vec(j);
         spec_norm2 += val * val;
     }
-    // TODO: I think this sqrt is wrong, only the second one is needed, do some tests to confirm
-    spec_norm2 = sqrt(spec_norm2);
     spec_norm = sqrt(spec_norm2);
 
     target = moment_target;
@@ -101,6 +99,7 @@ void Op_Moment::prox(Eigen::VectorXd &X) {
     if (do_equil) {
         X.array() /= eq_rows.array();
     }
+    X.array() *= spec_norm;
 
     for (int i = 0; i < X.size(); i++) {
         double lower_bound = (target - tol);
@@ -112,6 +111,7 @@ void Op_Moment::prox(Eigen::VectorXd &X) {
     if (do_equil) {
         X.array() *= eq_rows.array();
     }
+    X.array() /= spec_norm;
 
     spdlog::trace("Finished Op_Moment::prox");
 }
@@ -122,6 +122,7 @@ void Op_Moment::check(Eigen::VectorXd &X) {
     if (do_equil) {
         X.array() /= eq_rows.array();
     }
+    X.array() *= spec_norm;
 
     for (int i = 0; i < X.size(); i++) {
         double lower_bound = (target - tol0);
@@ -135,6 +136,7 @@ void Op_Moment::check(Eigen::VectorXd &X) {
     if (do_equil) {
         X.array() *= eq_rows.array();
     }
+    X.array() /= spec_norm;
 
     hist_feas.push_back(is_feas);
 }

--- a/gropt/src/op_safe.cpp
+++ b/gropt/src/op_safe.cpp
@@ -4,17 +4,14 @@
 
 namespace Gropt {
 
-Op_SAFE::Op_SAFE(const ProblemData &_pdata, double _stim_thresh, double _weight_mod)
-    : Operator(_pdata)
-{
+Op_SAFE::Op_SAFE(const ProblemData &_pdata, double _stim_thresh, double _weight_mod) : Operator(_pdata) {
     name = "SAFE";
     stim_thresh = _stim_thresh;
     weight_mod = _weight_mod;
 }
 
 Op_SAFE::Op_SAFE(const ProblemData &_pdata, int _N_vec, double *_stim_thresh_vec, double _weight_mod)
-    : Operator(_pdata)
-{
+    : Operator(_pdata) {
     name = "SAFE";
     stim_thresh = 1.0;
     weight_mod = _weight_mod;
@@ -25,16 +22,20 @@ Op_SAFE::Op_SAFE(const ProblemData &_pdata, int _N_vec, double *_stim_thresh_vec
     }
 }
 
-void Op_SAFE::init()
-{
+void Op_SAFE::init() {
     spdlog::trace("Op_SAFE::init  N = {}", pdata->N);
 
     safe_params.calc_alphas(pdata->dt);
 
+    if ((safe_params.a3[0] == 0) && (safe_params.a3[1] == 0) && (safe_params.a3[2] == 0)) {
+        n_terms = 2;
+        spdlog::trace("Op_SAFE::init  n_terms = {}", n_terms);
+    }
+
     // We will ignore this for now and just use stim_thresh_vec directly
     target = 0;
     tol0 = stim_thresh;
-    tol = (1.0-cushion) * tol0;
+    tol = (1.0 - cushion) * tol0;
 
     if (stim_thresh_vec.size() != pdata->Naxis * pdata->N) {
         if (stim_thresh_vec.size() != 0) {
@@ -46,117 +47,132 @@ void Op_SAFE::init()
         }
     }
 
-    spec_norm2 = 4.0/pdata->dt/pdata->dt;
+    spec_norm2 = 4.0 / pdata->dt / pdata->dt;
     spec_norm = sqrt(spec_norm2);
 
-    Ax_size = 3 * pdata->Naxis * pdata->N;
+    Ax_size = n_terms * pdata->Naxis * pdata->N;
 
     if (do_init_weights) {
         // weight is set on workspace, not here
     }
 
-    signs1.setZero(pdata->Naxis*pdata->N);
-    signs2.setZero(pdata->Naxis*pdata->N);
-    signs3.setZero(pdata->Naxis*pdata->N);
-    stim1.setZero(pdata->Naxis*pdata->N);
-    stim2.setZero(pdata->Naxis*pdata->N);
-    stim3.setZero(pdata->Naxis*pdata->N);
+    signs1.setZero(pdata->Naxis * pdata->N);
+    signs2.setZero(pdata->Naxis * pdata->N);
+    signs3.setZero(pdata->Naxis * pdata->N);
+    stim1.setZero(pdata->Naxis * pdata->N);
+    stim2.setZero(pdata->Naxis * pdata->N);
+    stim3.setZero(pdata->Naxis * pdata->N);
 
     Operator::init();
 
     spdlog::trace("Op_SAFE::init  Done!");
 }
 
-void Op_SAFE::forward(Eigen::VectorXd &X, Eigen::VectorXd &out)
-{
+void Op_SAFE::forward(Eigen::VectorXd &X, Eigen::VectorXd &out) {
     // out = diff(X)/dt
     for (int j = 0; j < Naxis; j++) {
-        out(j*N) = X(j*N)/dt;
+        out(j * N) = X(j * N) / dt;
         for (int i = 1; i < N; i++) {
-            out(j*N+i) = (X(j*N+i) - X(j*N+i-1))/dt;
+            out(j * N + i) = (X(j * N + i) - X(j * N + i - 1)) / dt;
         }
     }
 
     // stim1 = tau_filter_1(dX/dt)
     stim1.setZero();
     for (int j = 0; j < Naxis; j++) {
-        stim1(j*N) = safe_params.alpha1[j] * out(j*N);
+        stim1(j * N) = safe_params.alpha1[j] * out(j * N);
         for (int i = 1; i < N; i++) {
-            stim1(j*N+i) = safe_params.alpha1[j] * out(j*N+i) + (1.0-safe_params.alpha1[j]) * stim1(j*N+i-1);
+            stim1(j * N + i) =
+                safe_params.alpha1[j] * out(j * N + i) + (1.0 - safe_params.alpha1[j]) * stim1(j * N + i - 1);
         }
     }
 
     // stim1 = abs(tau_filter_1(dX/dt))
     for (int i = 0; i < stim1.size(); i++) {
-        if (stim1(i) < 0) {signs1(i) = -1.0;}
-        else {signs1(i) = 1.0;}
+        if (stim1(i) < 0) {
+            signs1(i) = -1.0;
+        } else {
+            signs1(i) = 1.0;
+        }
         stim1(i) = abs(stim1(i));
     }
-
 
     // stim2 = dX/dt
     for (int j = 0; j < Naxis; j++) {
         for (int i = 0; i < N; i++) {
-            stim2(j*N+i) = out(j*N+i);
+            stim2(j * N + i) = out(j * N + i);
         }
     }
 
     // stim2 = abs(dX/dt)
     for (int i = 0; i < stim1.size(); i++) {
-        if (stim2(i) < 0) {signs2(i) = -1.0;}
-        else {signs2(i) = 1.0;}
+        if (stim2(i) < 0) {
+            signs2(i) = -1.0;
+        } else {
+            signs2(i) = 1.0;
+        }
         stim2(i) = abs(stim2(i));
     }
 
-
     // stim2 = tau_filter_2(abs(dX/dt))
     for (int j = 0; j < Naxis; j++) {
-        stim2(j*N) = safe_params.alpha2[j] * stim2(j*N);
+        stim2(j * N) = safe_params.alpha2[j] * stim2(j * N);
         for (int i = 1; i < N; i++) {
-            stim2(j*N+i) = safe_params.alpha2[j] * stim2(j*N+i) + (1.0-safe_params.alpha2[j]) * stim2(j*N+i-1);
+            stim2(j * N + i) =
+                safe_params.alpha2[j] * stim2(j * N + i) + (1.0 - safe_params.alpha2[j]) * stim2(j * N + i - 1);
         }
     }
-
 
     // stim3 = tau_filter_3(dX/dt)
     stim3.setZero();
     for (int j = 0; j < Naxis; j++) {
-        stim3(j*N) = safe_params.alpha3[j] * out(j*N);
+        stim3(j * N) = safe_params.alpha3[j] * out(j * N);
         for (int i = 1; i < N; i++) {
-            stim3(j*N+i) = safe_params.alpha3[j] * out(j*N+i) + (1.0-safe_params.alpha3[j]) * stim3(j*N+i-1);
+            stim3(j * N + i) =
+                safe_params.alpha3[j] * out(j * N + i) + (1.0 - safe_params.alpha3[j]) * stim3(j * N + i - 1);
         }
     }
 
     // stim3 = abs(tau_filter_3(dX/dt))
     for (int i = 0; i < stim3.size(); i++) {
-        if (stim3(i) < 0) {signs3(i) = -1.0;}
-        else {signs3(i) = 1.0;}
+        if (stim3(i) < 0) {
+            signs3(i) = -1.0;
+        } else {
+            signs3(i) = 1.0;
+        }
         stim3(i) = abs(stim3(i));
     }
 
     // The return vector is [stim1; stim2; stim3] scaled by a, stim_limit, g_scale
     for (int j = 0; j < Naxis; j++) {
         for (int i = 0; i < N; i++) {
-            out(j*3*N + i) = safe_params.a1[j] * stim1(j*N+i) / safe_params.stim_limit[j] * safe_params.g_scale[j];
-            out(j*3*N + i+N) = safe_params.a2[j] * stim2(j*N+i) / safe_params.stim_limit[j] * safe_params.g_scale[j];
-            out(j*3*N + i+2*N) = safe_params.a3[j] * stim3(j*N+i) / safe_params.stim_limit[j] * safe_params.g_scale[j];
+            out(j * n_terms * N + i) =
+                safe_params.a1[j] * stim1(j * N + i) / safe_params.stim_limit[j] * safe_params.g_scale[j];
+            out(j * n_terms * N + i + N) =
+                safe_params.a2[j] * stim2(j * N + i) / safe_params.stim_limit[j] * safe_params.g_scale[j];
+            if (n_terms == 3) {
+                out(j * n_terms * N + i + 2 * N) =
+                    safe_params.a3[j] * stim3(j * N + i) / safe_params.stim_limit[j] * safe_params.g_scale[j];
+            }
         }
     }
-
 }
 
-void Op_SAFE::transpose(Eigen::VectorXd &X, Eigen::VectorXd &out)
-{
+void Op_SAFE::transpose(Eigen::VectorXd &X, Eigen::VectorXd &out) {
 
     // Split and scale by a, stim_limit, g_scale
     for (int j = 0; j < Naxis; j++) {
         for (int i = 0; i < N; i++) {
-            stim1(j*N+i) = safe_params.a1[j] * X(j*3*N + i) / safe_params.stim_limit[j] * safe_params.g_scale[j];
-            stim2(j*N+i) = safe_params.a2[j] * X(j*3*N + i+N) / safe_params.stim_limit[j] * safe_params.g_scale[j];
-            stim3(j*N+i) = safe_params.a3[j] * X(j*3*N + i+2*N) / safe_params.stim_limit[j] * safe_params.g_scale[j];
+            stim1(j * N + i) =
+                safe_params.a1[j] * X(j * n_terms * N + i) / safe_params.stim_limit[j] * safe_params.g_scale[j];
+            stim2(j * N + i) =
+                safe_params.a2[j] * X(j * n_terms * N + i + N) / safe_params.stim_limit[j] * safe_params.g_scale[j];
+            if (n_terms == 3) {
+                stim3(j * N + i) = safe_params.a3[j] * X(j * n_terms * N + i + 2 * N) / safe_params.stim_limit[j] *
+                                   safe_params.g_scale[j];
+            }
         }
     }
-
 
     // stim1 = signs1 * stim1
     for (int i = 0; i < stim1.size(); i++) {
@@ -165,18 +181,19 @@ void Op_SAFE::transpose(Eigen::VectorXd &X, Eigen::VectorXd &out)
 
     // stim1 = tau_filter_1_T(stim1)
     for (int j = 0; j < Naxis; j++) {
-        stim1(j*N+N-1) = safe_params.alpha1[j] * stim1(j*N+N-1);
-        for (int i = N-2; i >= 0; i--) {
-            stim1(j*N+i) = safe_params.alpha1[j] * stim1(j*N+i) + (1-safe_params.alpha1[j]) * stim1(j*N+i+1);
+        stim1(j * N + N - 1) = safe_params.alpha1[j] * stim1(j * N + N - 1);
+        for (int i = N - 2; i >= 0; i--) {
+            stim1(j * N + i) =
+                safe_params.alpha1[j] * stim1(j * N + i) + (1 - safe_params.alpha1[j]) * stim1(j * N + i + 1);
         }
     }
 
-
     // stim2 = tau_filter_2_T(stim2)
     for (int j = 0; j < Naxis; j++) {
-        stim2(j*N+N-1) = safe_params.alpha2[j] * stim2(j*N+N-1);
-        for (int i = N-2; i >= 0; i--) {
-            stim2(j*N+i) = safe_params.alpha2[j] * stim2(j*N+i) + (1-safe_params.alpha2[j]) * stim2(j*N+i+1);
+        stim2(j * N + N - 1) = safe_params.alpha2[j] * stim2(j * N + N - 1);
+        for (int i = N - 2; i >= 0; i--) {
+            stim2(j * N + i) =
+                safe_params.alpha2[j] * stim2(j * N + i) + (1 - safe_params.alpha2[j]) * stim2(j * N + i + 1);
         }
     }
 
@@ -185,109 +202,136 @@ void Op_SAFE::transpose(Eigen::VectorXd &X, Eigen::VectorXd &out)
         stim2(i) = signs2(i) * stim2(i);
     }
 
+    if (n_terms == 3) {
 
+        // stim3 = signs3 * stim3
+        for (int i = 0; i < stim3.size(); i++) {
+            stim3(i) = signs3(i) * stim3(i);
+        }
 
-    // stim3 = signs3 * stim3
-    for (int i = 0; i < stim3.size(); i++) {
-        stim3(i) = signs3(i) * stim3(i);
-    }
-
-    // stim3 = tau_filter_3_T(stim3)
-    for (int j = 0; j < Naxis; j++) {
-        stim3(j*N+N-1) = safe_params.alpha3[j] * stim3(j*N+N-1);
-        for (int i = N-2; i >= 0; i--) {
-            stim3(j*N+i) = safe_params.alpha3[j] * stim3(j*N+i) + (1-safe_params.alpha3[j]) * stim3(j*N+i+1);
+        // stim3 = tau_filter_3_T(stim3)
+        for (int j = 0; j < Naxis; j++) {
+            stim3(j * N + N - 1) = safe_params.alpha3[j] * stim3(j * N + N - 1);
+            for (int i = N - 2; i >= 0; i--) {
+                stim3(j * N + i) =
+                    safe_params.alpha3[j] * stim3(j * N + i) + (1 - safe_params.alpha3[j]) * stim3(j * N + i + 1);
+            }
         }
     }
 
     for (int j = 0; j < Naxis; j++) {
         for (int i = 0; i < N; i++) {
-            out(j*N+i) = stim1(j*N+i) + stim2(j*N+i) + stim3(j*N+i);
+            if (n_terms == 3) {
+                out(j * N + i) = stim1(j * N + i) + stim2(j * N + i) + stim3(j * N + i);
+            } else if (n_terms == 2) {
+                out(j * N + i) = stim1(j * N + i) + stim2(j * N + i);
+            }
         }
     }
 
     // out = diff(stim1 + stim2 + stim3)/dt
     for (int j = 0; j < Naxis; j++) {
-        for (int i = 0; i < N-1; i++) {
-            out(j*N+i) = (out(j*N+i) - out(j*N+i+1))/dt;
+        for (int i = 0; i < N - 1; i++) {
+            out(j * N + i) = (out(j * N + i) - out(j * N + i + 1)) / dt;
         }
-        out(j*N+N-1) = out(j*N+N-1)/dt;
+        out(j * N + N - 1) = out(j * N + N - 1) / dt;
     }
 }
 
-void Op_SAFE::prox(Eigen::VectorXd &X)
-{
+void Op_SAFE::prox(Eigen::VectorXd &X) {
     spdlog::trace("Starting Op_SAFE::prox");
+
+    if (do_equil) {
+        X.array() /= eq_rows.array();
+    }
 
     // This just sums the three terms [stim1, stim2, stim3], it is not the cross axis sum.
     x_temp.setZero();
     for (int j = 0; j < Naxis; j++) {
         for (int i = 0; i < N; i++) {
-            x_temp(j*N+i) = X(j*3*N+i) + X(j*3*N+i+N) + X(j*3*N+i+2*N);
+            if (n_terms == 3) {
+                x_temp(j * N + i) =
+                    X(j * n_terms * N + i) + X(j * n_terms * N + i + N) + X(j * n_terms * N + i + 2 * N);
+            } else if (n_terms == 2) {
+                x_temp(j * N + i) = X(j * n_terms * N + i) + X(j * n_terms * N + i + N);
+            }
         }
     }
 
     if (rot_variant) {
         for (int j = 0; j < Naxis; j++) {
-        for (int i = 0; i < N; i++) {
-            double val = abs(x_temp(j*N+i));
+            for (int i = 0; i < N; i++) {
+                double val = abs(x_temp(j * N + i));
 
-            double upper_bound = (1-cushion) * stim_thresh_vec(j*N+i);
-            if (val > upper_bound) {
-                X(j*3*N+i) *= (upper_bound/val);
-                X(j*3*N+i+N) *= (upper_bound/val);
-                X(j*3*N+i+2*N) *= (upper_bound/val);
+                double upper_bound = (1 - cushion) * stim_thresh_vec(j * N + i);
+                if (val > upper_bound) {
+                    X(j * n_terms * N + i) *= (upper_bound / val);
+                    X(j * n_terms * N + i + N) *= (upper_bound / val);
+                    if (n_terms == 3) {
+                        X(j * n_terms * N + i + 2 * N) *= (upper_bound / val);
+                    }
+                }
             }
-        }
         }
     } else {
         for (int i = 0; i < N; i++) {
             double val = 0.0;
             for (int j = 0; j < Naxis; j++) {
-                val += X(j*N+i)*X(j*N+i);
+                val += X(j * N + i) * X(j * N + i);
             }
             val = sqrt(val);
-            double upper_bound = (1-cushion) * stim_thresh_vec(i);
+            double upper_bound = (1 - cushion) * stim_thresh_vec(i);
 
             if (val > upper_bound) {
                 for (int j = 0; j < Naxis; j++) {
-                    X(j*N+i) *= (upper_bound/val);
+                    X(j * N + i) *= (upper_bound / val);
                 }
             }
         }
     }
 
+    if (do_equil) {
+        X.array() *= eq_rows.array();
+    }
+
     spdlog::trace("Finished Op_SAFE::prox");
 }
 
-
-void Op_SAFE::check(Eigen::VectorXd &X)
-{
+void Op_SAFE::check(Eigen::VectorXd &X) {
     int is_feas = 1;
+
+    if (do_equil) {
+        X.array() /= eq_rows.array();
+    }
 
     x_temp.setZero();
     for (int j = 0; j < Naxis; j++) {
         for (int i = 0; i < N; i++) {
-            x_temp(j*N+i) = X(j*3*N+i) + X(j*3*N+i+N) + X(j*3*N+i+2*N);
+            if (n_terms == 3) {
+                x_temp(j * N + i) =
+                    X(j * n_terms * N + i) + X(j * n_terms * N + i + N) + X(j * n_terms * N + i + 2 * N);
+            } else if (n_terms == 2) {
+                x_temp(j * N + i) = X(j * n_terms * N + i) + X(j * n_terms * N + i + N);
+            }
         }
     }
 
     if (rot_variant) {
         for (int j = 0; j < Naxis; j++) {
-        for (int i = 0; i < N; i++) {
-            double val = abs(x_temp(j*N+i));
-            double upper_bound = stim_thresh_vec(j*N+i);
+            for (int i = 0; i < N; i++) {
+                double val = abs(x_temp(j * N + i));
+                double upper_bound = stim_thresh_vec(j * N + i);
 
-            if (val > upper_bound) {
-                is_feas = 0;
+                if (val > upper_bound) {
+                    is_feas = 0;
+                }
             }
-        }
         }
     } else {
         for (int i = 0; i < N; i++) {
             double val = 0.0;
             for (int j = 0; j < Naxis; j++) {
-                val += X(j*N+i)*X(j*N+i);
+                val += X(j * N + i) * X(j * N + i);
             }
             val = sqrt(val);
             double upper_bound = stim_thresh_vec(i);
@@ -298,33 +342,35 @@ void Op_SAFE::check(Eigen::VectorXd &X)
         }
     }
 
+    if (do_equil) {
+        X.array() *= eq_rows.array();
+    }
+
     hist_feas.push_back(is_feas);
 }
 
-
-void SAFEParams::set_demo_params()
-{
-    tau1[0] = 0.135/1000.0;
-    tau2[0] = 12.0/1000.0;
-    tau3[0] = 0.5175/1000.0;
+void SAFEParams::set_demo_params() {
+    tau1[0] = 0.135 / 1000.0;
+    tau2[0] = 12.0 / 1000.0;
+    tau3[0] = 0.5175 / 1000.0;
     a1[0] = 0.3130;
     a2[0] = 0.1995;
     a3[0] = 0.4875;
     stim_limit[0] = 27.894;
     g_scale[0] = 0.325;
 
-    tau1[1] = 1.5/1000.0;
-    tau2[1] = 2.5/1000.0;
-    tau3[1] = 0.15/1000.0;
+    tau1[1] = 1.5 / 1000.0;
+    tau2[1] = 2.5 / 1000.0;
+    tau3[1] = 0.15 / 1000.0;
     a1[1] = 0.55;
     a2[1] = 0.15;
     a3[1] = 0.3;
     stim_limit[1] = 15;
     g_scale[1] = 0.31;
 
-    tau1[2] = 2/1000.0;
-    tau2[2] = 0.12/1000.0;
-    tau3[2] = 1/1000.0;
+    tau1[2] = 2 / 1000.0;
+    tau2[2] = 0.12 / 1000.0;
+    tau3[2] = 1 / 1000.0;
     a1[2] = 0.42;
     a2[2] = 0.4;
     a3[2] = 0.18;
@@ -332,10 +378,8 @@ void SAFEParams::set_demo_params()
     g_scale[2] = 0.25;
 }
 
-void SAFEParams::set_params(double *_tau1, double *_tau2, double *_tau3,
-                            double *_a1, double *_a2, double *_a3,
-                            double *_stim_limit, double *_g_scale)
-{
+void SAFEParams::set_params(double *_tau1, double *_tau2, double *_tau3, double *_a1, double *_a2, double *_a3,
+                            double *_stim_limit, double *_g_scale) {
     for (int i = 0; i < 3; i++) {
         tau1[i] = _tau1[i];
         tau2[i] = _tau2[i];
@@ -348,8 +392,7 @@ void SAFEParams::set_params(double *_tau1, double *_tau2, double *_tau3,
     }
 }
 
-void SAFEParams::swap_first_axes(int new_first_axis)
-{
+void SAFEParams::swap_first_axes(int new_first_axis) {
     if (new_first_axis < 0 || new_first_axis >= 3) {
         spdlog::error("Invalid axis index: {}", new_first_axis);
         return;
@@ -365,14 +408,12 @@ void SAFEParams::swap_first_axes(int new_first_axis)
     }
 }
 
-void SAFEParams::calc_alphas(double dt)
-{
+void SAFEParams::calc_alphas(double dt) {
     for (int i = 0; i < 3; i++) {
-        alpha1[i] = dt/(tau1[i] + dt);
-        alpha2[i] = dt/(tau2[i] + dt);
-        alpha3[i] = dt/(tau3[i] + dt);
+        alpha1[i] = dt / (tau1[i] + dt);
+        alpha2[i] = dt / (tau2[i] + dt);
+        alpha3[i] = dt / (tau3[i] + dt);
     }
 }
 
-
-}  // close "namespace Gropt"
+} // namespace Gropt

--- a/gropt/src/op_safe.cpp
+++ b/gropt/src/op_safe.cpp
@@ -47,7 +47,7 @@ void Op_SAFE::init() {
         }
     }
 
-    spec_norm2 = 4.0 / pdata->dt / pdata->dt;
+    spec_norm2 = 4.0 / pdata->dt / pdata->dt * 1.69e-05;
     spec_norm = sqrt(spec_norm2);
 
     Ax_size = n_terms * pdata->Naxis * pdata->N;
@@ -244,6 +244,7 @@ void Op_SAFE::prox(Eigen::VectorXd &X) {
     if (do_equil) {
         X.array() /= eq_rows.array();
     }
+    X.array() *= spec_norm;
 
     // This just sums the three terms [stim1, stim2, stim3], it is not the cross axis sum.
     x_temp.setZero();
@@ -293,6 +294,7 @@ void Op_SAFE::prox(Eigen::VectorXd &X) {
     if (do_equil) {
         X.array() *= eq_rows.array();
     }
+    X.array() /= spec_norm;
 
     spdlog::trace("Finished Op_SAFE::prox");
 }
@@ -303,6 +305,7 @@ void Op_SAFE::check(Eigen::VectorXd &X) {
     if (do_equil) {
         X.array() /= eq_rows.array();
     }
+    X.array() *= spec_norm;
 
     x_temp.setZero();
     for (int j = 0; j < Naxis; j++) {
@@ -345,6 +348,7 @@ void Op_SAFE::check(Eigen::VectorXd &X) {
     if (do_equil) {
         X.array() *= eq_rows.array();
     }
+    X.array() /= spec_norm;
 
     hist_feas.push_back(is_feas);
 }

--- a/gropt/src/op_safe.cpp
+++ b/gropt/src/op_safe.cpp
@@ -10,16 +10,12 @@ Op_SAFE::Op_SAFE(const ProblemData &_pdata, double _stim_thresh, double _weight_
     weight_mod = _weight_mod;
 }
 
-Op_SAFE::Op_SAFE(const ProblemData &_pdata, int _N_vec, double *_stim_thresh_vec, double _weight_mod)
+Op_SAFE::Op_SAFE(const ProblemData &_pdata, const Eigen::VectorXd &_stim_thresh_vec, double _weight_mod)
     : Operator(_pdata) {
     name = "SAFE";
     stim_thresh = 1.0;
     weight_mod = _weight_mod;
-
-    stim_thresh_vec.resize(_N_vec);
-    for (int i = 0; i < stim_thresh_vec.size(); i++) {
-        stim_thresh_vec(i) = _stim_thresh_vec[i];
-    }
+    stim_thresh_vec = _stim_thresh_vec;
 }
 
 void Op_SAFE::init() {
@@ -382,17 +378,18 @@ void SAFEParams::set_demo_params() {
     g_scale[2] = 0.25;
 }
 
-void SAFEParams::set_params(double *_tau1, double *_tau2, double *_tau3, double *_a1, double *_a2, double *_a3,
-                            double *_stim_limit, double *_g_scale) {
+void SAFEParams::set_params(const Eigen::VectorXd &_tau1, const Eigen::VectorXd &_tau2, const Eigen::VectorXd &_tau3,
+                            const Eigen::VectorXd &_a1, const Eigen::VectorXd &_a2, const Eigen::VectorXd &_a3,
+                            const Eigen::VectorXd &_stim_limit, const Eigen::VectorXd &_g_scale) {
     for (int i = 0; i < 3; i++) {
-        tau1[i] = _tau1[i];
-        tau2[i] = _tau2[i];
-        tau3[i] = _tau3[i];
-        a1[i] = _a1[i];
-        a2[i] = _a2[i];
-        a3[i] = _a3[i];
-        stim_limit[i] = _stim_limit[i];
-        g_scale[i] = _g_scale[i];
+        tau1[i] = _tau1(i);
+        tau2[i] = _tau2(i);
+        tau3[i] = _tau3(i);
+        a1[i] = _a1(i);
+        a2[i] = _a2(i);
+        a3[i] = _a3(i);
+        stim_limit[i] = _stim_limit(i);
+        g_scale[i] = _g_scale(i);
     }
 }
 

--- a/gropt/src/op_safe.hpp
+++ b/gropt/src/op_safe.hpp
@@ -5,10 +5,10 @@
  * Constriant on SAFE model prediction of waveforms.
  */
 
-#include <iostream>
-#include <string>
-#include <math.h>
 #include "Eigen/Dense"
+#include <iostream>
+#include <math.h>
+#include <string>
 
 #include "op_main.hpp"
 
@@ -16,59 +16,56 @@ namespace Gropt {
 
 class SAFEParams {
 
-    public:
+  public:
+    std::vector<double> tau1 = std::vector<double>(3, 0.0);
+    std::vector<double> tau2 = std::vector<double>(3, 0.0);
+    std::vector<double> tau3 = std::vector<double>(3, 0.0);
+    std::vector<double> a1 = std::vector<double>(3, 0.0);
+    std::vector<double> a2 = std::vector<double>(3, 0.0);
+    std::vector<double> a3 = std::vector<double>(3, 0.0);
+    std::vector<double> stim_limit = std::vector<double>(3, 0.0);
+    std::vector<double> g_scale = std::vector<double>(3, 0.0);
 
-        std::vector<double> tau1 = std::vector<double>(3, 0.0);
-        std::vector<double> tau2 = std::vector<double>(3, 0.0);
-        std::vector<double> tau3 = std::vector<double>(3, 0.0);
-        std::vector<double> a1 = std::vector<double>(3, 0.0);
-        std::vector<double> a2 = std::vector<double>(3, 0.0);
-        std::vector<double> a3 = std::vector<double>(3, 0.0);
-        std::vector<double> stim_limit = std::vector<double>(3, 0.0);
-        std::vector<double> g_scale = std::vector<double>(3, 0.0);
+    // These aren't real parameters because they depend on dt, maybe they should be in Op_SAFE?
+    std::vector<double> alpha1 = std::vector<double>(3, 0.0);
+    std::vector<double> alpha2 = std::vector<double>(3, 0.0);
+    std::vector<double> alpha3 = std::vector<double>(3, 0.0);
 
-        // These aren't real parameters because they depend on dt, maybe they should be in Op_SAFE?
-        std::vector<double> alpha1 = std::vector<double>(3, 0.0);
-        std::vector<double> alpha2 = std::vector<double>(3, 0.0);
-        std::vector<double> alpha3 = std::vector<double>(3, 0.0);
-
-
-        SAFEParams() = default;
-        void set_demo_params();
-        void set_params(double *_tau1, double *_tau2, double *_tau3,
-                            double *_a1, double *_a2, double *_a3,
-                            double *_stim_limit, double *_g_scale);
-        void calc_alphas(double dt);
-        void swap_first_axes(int new_first_axis);
+    SAFEParams() = default;
+    void set_demo_params();
+    void set_params(double *_tau1, double *_tau2, double *_tau3, double *_a1, double *_a2, double *_a3,
+                    double *_stim_limit, double *_g_scale);
+    void calc_alphas(double dt);
+    void swap_first_axes(int new_first_axis);
 };
 
-class Op_SAFE : public Operator
-{
-    protected:
-        double stim_thresh;
-        Eigen::VectorXd stim_thresh_vec;
+class Op_SAFE : public Operator {
+  protected:
+    double stim_thresh;
 
-        Eigen::VectorXd signs1;
-        Eigen::VectorXd signs2;
-        Eigen::VectorXd signs3;
-        Eigen::VectorXd stim1;
-        Eigen::VectorXd stim2;
-        Eigen::VectorXd stim3;
+    Eigen::VectorXd stim_thresh_vec;
 
-    public:
-        SAFEParams safe_params;
+    Eigen::VectorXd signs1;
+    Eigen::VectorXd signs2;
+    Eigen::VectorXd signs3;
+    Eigen::VectorXd stim1;
+    Eigen::VectorXd stim2;
+    Eigen::VectorXd stim3;
 
-        Op_SAFE(const ProblemData &_pdata, double _stim_thresh, double _weight_mod);
-        Op_SAFE(const ProblemData &_pdata, int _N_vec, double *_stim_thresh_vec, double _weight_mod);
-        virtual void init();
+  public:
+    SAFEParams safe_params;
+    int n_terms = 3;
 
-        virtual void forward(Eigen::VectorXd &X, Eigen::VectorXd &out);
-        virtual void transpose(Eigen::VectorXd &X, Eigen::VectorXd &out);
-        virtual void prox(Eigen::VectorXd &X);
-        virtual void check(Eigen::VectorXd &X);
+    Op_SAFE(const ProblemData &_pdata, double _stim_thresh, double _weight_mod);
+    Op_SAFE(const ProblemData &_pdata, int _N_vec, double *_stim_thresh_vec, double _weight_mod);
+    virtual void init();
 
+    virtual void forward(Eigen::VectorXd &X, Eigen::VectorXd &out);
+    virtual void transpose(Eigen::VectorXd &X, Eigen::VectorXd &out);
+    virtual void prox(Eigen::VectorXd &X);
+    virtual void check(Eigen::VectorXd &X);
 };
 
-}  // close "namespace Gropt"
+} // namespace Gropt
 
 #endif

--- a/gropt/src/op_safe.hpp
+++ b/gropt/src/op_safe.hpp
@@ -33,8 +33,9 @@ class SAFEParams {
 
     SAFEParams() = default;
     void set_demo_params();
-    void set_params(double *_tau1, double *_tau2, double *_tau3, double *_a1, double *_a2, double *_a3,
-                    double *_stim_limit, double *_g_scale);
+    void set_params(const Eigen::VectorXd &_tau1, const Eigen::VectorXd &_tau2, const Eigen::VectorXd &_tau3,
+                    const Eigen::VectorXd &_a1, const Eigen::VectorXd &_a2, const Eigen::VectorXd &_a3,
+                    const Eigen::VectorXd &_stim_limit, const Eigen::VectorXd &_g_scale);
     void calc_alphas(double dt);
     void swap_first_axes(int new_first_axis);
 };
@@ -57,7 +58,7 @@ class Op_SAFE : public Operator {
     int n_terms = 3;
 
     Op_SAFE(const ProblemData &_pdata, double _stim_thresh, double _weight_mod);
-    Op_SAFE(const ProblemData &_pdata, int _N_vec, double *_stim_thresh_vec, double _weight_mod);
+    Op_SAFE(const ProblemData &_pdata, const Eigen::VectorXd &_stim_thresh_vec, double _weight_mod);
     virtual void init();
 
     virtual void forward(Eigen::VectorXd &X, Eigen::VectorXd &out);

--- a/gropt/src/op_slew.cpp
+++ b/gropt/src/op_slew.cpp
@@ -55,6 +55,7 @@ void Op_Slew::prox(Eigen::VectorXd &X) {
     if (do_equil) {
         X.array() /= eq_rows.array();
     }
+    X.array() *= spec_norm;
 
     if (rot_variant) {
         for (int i = 0; i < X.size(); i++) {
@@ -84,6 +85,7 @@ void Op_Slew::prox(Eigen::VectorXd &X) {
     if (do_equil) {
         X.array() *= eq_rows.array();
     }
+    X.array() /= spec_norm;
 
     spdlog::trace("Finished Op_Slew::prox");
 }
@@ -94,6 +96,7 @@ void Op_Slew::check(Eigen::VectorXd &X) {
     if (do_equil) {
         X.array() /= eq_rows.array();
     }
+    X.array() *= spec_norm;
 
     if (rot_variant) {
         for (int i = 0; i < X.size(); i++) {
@@ -141,6 +144,7 @@ void Op_Slew::check(Eigen::VectorXd &X) {
     if (do_equil) {
         X.array() *= eq_rows.array();
     }
+    X.array() /= spec_norm;
 }
 
 } // namespace Gropt

--- a/gropt/src/solver.cpp
+++ b/gropt/src/solver.cpp
@@ -4,14 +4,12 @@
 
 namespace Gropt {
 
-SolveResult Solver::solve(GroptParams &_gparams)
-{
+SolveResult Solver::solve(GroptParams &_gparams) {
     spdlog::warn("Solver::solve is not implemented for the base class.");
     return SolveResult{};
 }
 
-int Solver::logger(Eigen::VectorXd &X)
-{
+int Solver::logger(Eigen::VectorXd &X) {
     bool do_print = (iiter % log_interval == 0);
     int all_feasible = 1;
 
@@ -24,13 +22,13 @@ int Solver::logger(Eigen::VectorXd &X)
     }
     for (int i = 0; i < gparams->all_op.size(); i++) {
         if (do_print) {
-            spdlog::debug("    {:^16}    {:d}       {:.1e}    {:.1e}   {:.1e}",
-                gparams->all_op[i]->name, gparams->all_op[i]->hist_feas.back(), ws[i]->weight, ws[i]->gamma, gparams->all_op[i]->hist_r_feas.back());
+            spdlog::debug("    {:^16}    {:d}       {:.1e}    {:.1e}   {:.1e}", gparams->all_op[i]->name,
+                          gparams->all_op[i]->hist_feas.back(), ws[i]->weight, ws[i]->gamma,
+                          gparams->all_op[i]->hist_r_feas.back());
         }
         if (gparams->all_op[i]->hist_feas.back() == 0) {
             all_feasible = 0;
         }
-
     }
 
     hist_cg_iter.push_back(ils_solver->hist_n_iter.back());
@@ -38,8 +36,7 @@ int Solver::logger(Eigen::VectorXd &X)
     return all_feasible;
 }
 
-void Solver::final_log(Eigen::VectorXd &X, SolveResult &result)
-{
+void Solver::final_log(Eigen::VectorXd &X, SolveResult &result) {
 
     result.converged = true;
 
@@ -58,8 +55,8 @@ void Solver::final_log(Eigen::VectorXd &X, SolveResult &result)
         op->Ax_temp.setZero();
         op->forward_op(X, op->Ax_temp);
 
-        spdlog::info("    {:^16}    {:d}       {: .2e}    {: .2e}    {: .2e}",
-            op->name, op->hist_feas.back(), op->Ax_temp.minCoeff()-op->target, op->Ax_temp.maxCoeff()-op->target, op->tol0);
+        spdlog::info("    {:^16}    {:d}       {: .2e}    {: .2e}    {: .2e}", op->name, op->hist_feas.back(),
+                     op->Ax_temp.minCoeff() - op->target, op->Ax_temp.maxCoeff() - op->target, op->tol0);
 
         if (op->hist_feas.back() == 0) {
             result.converged = false;
@@ -67,8 +64,7 @@ void Solver::final_log(Eigen::VectorXd &X, SolveResult &result)
     }
 }
 
-void Solver::set_general_params(int min_iter, int max_iter, int log_interval, double gamma_x, int max_feval)
-{
+void Solver::set_general_params(int min_iter, int max_iter, int log_interval, double gamma_x, int max_feval) {
     this->min_iter = min_iter;
     this->max_iter = max_iter;
     this->log_interval = log_interval;
@@ -76,8 +72,7 @@ void Solver::set_general_params(int min_iter, int max_iter, int log_interval, do
     this->max_feval = max_feval;
 }
 
-void Solver::set_ils_params(double ils_tol, int ils_max_iter, int ils_min_iter, double ils_sigma, double ils_tik_lam)
-{
+void Solver::set_ils_params(double ils_tol, int ils_max_iter, int ils_min_iter, double ils_sigma, double ils_tik_lam) {
     this->ils_tol = ils_tol;
     this->ils_max_iter = ils_max_iter;
     this->ils_min_iter = ils_min_iter;

--- a/gropt/src/solver.cpp
+++ b/gropt/src/solver.cpp
@@ -64,12 +64,14 @@ void Solver::final_log(Eigen::VectorXd &X, SolveResult &result) {
     }
 }
 
-void Solver::set_general_params(int min_iter, int max_iter, int log_interval, double gamma_x, int max_feval) {
+void Solver::set_general_params(int min_iter, int max_iter, int log_interval, double gamma_x, int max_feval,
+                                int extra_iters) {
     this->min_iter = min_iter;
     this->max_iter = max_iter;
     this->log_interval = log_interval;
     this->gamma_x = gamma_x;
     this->max_feval = max_feval;
+    this->extra_iters = extra_iters;
 }
 
 void Solver::set_ils_params(double ils_tol, int ils_max_iter, int ils_min_iter, double ils_sigma, double ils_tik_lam) {

--- a/gropt/src/solver.hpp
+++ b/gropt/src/solver.hpp
@@ -21,6 +21,9 @@ struct DebugSolver {
     std::vector<Eigen::VectorXd> hist_z;
     std::vector<Eigen::VectorXd> hist_y;
     std::vector<Eigen::VectorXd> hist_Aty;
+    std::vector<std::vector<double>> hist_weight;
+    std::vector<std::vector<double>> hist_gamma;
+    std::vector<double> hist_gamma_x;
 };
 
 class Solver {

--- a/gropt/src/solver.hpp
+++ b/gropt/src/solver.hpp
@@ -1,58 +1,66 @@
 #ifndef SOLVER_H
 #define SOLVER_H
 
-#include <iostream>
-#include <string>
-#include <numeric>
-#include <vector>
 #include "Eigen/Dense"
+#include <iostream>
+#include <numeric>
+#include <string>
+#include <vector>
 
 #include "gropt_params.hpp"
-#include "workspace_solver.hpp"
 #include "ils.hpp"
+#include "workspace_solver.hpp"
 
-namespace Gropt
-{
+namespace Gropt {
 
-    class GroptParams; // Forward declaration of GroptParams class
+class GroptParams; // Forward declaration of GroptParams class
 
-    class Solver
-    {
-    public:
-        GroptParams *gparams;
-        IndirectLinearSolver *ils_solver;
+struct DebugSolver {
+    std::vector<Eigen::VectorXd> hist_X;
+    std::vector<Eigen::VectorXd> hist_Ax;
+    std::vector<Eigen::VectorXd> hist_z;
+    std::vector<Eigen::VectorXd> hist_y;
+    std::vector<Eigen::VectorXd> hist_Aty;
+};
 
-        // Per-operator workspaces (pointers into subclass-owned typed vectors)
-        std::vector<WorkspaceSolver*> ws;
+class Solver {
+  public:
+    GroptParams *gparams;
+    IndirectLinearSolver *ils_solver;
 
-        int max_iter = 2000;
-        int max_feval = 12000;
-        int log_interval = 20;
-        int min_iter = 0;
-        double gamma_x = 1.6;
+    // Per-operator workspaces (pointers into subclass-owned typed vectors)
+    std::vector<WorkspaceSolver *> ws;
 
-        double ils_tol = 1e-3;
-        int ils_max_iter = 10;
-        int ils_min_iter = 2;
-        double ils_sigma = 1e-4;
-        double ils_tik_lam = 1e-4;
+    int max_iter = 2000;
+    int max_feval = 12000;
+    int log_interval = 20;
+    int min_iter = 0;
+    double gamma_x = 1.6;
 
-        bool extra_debug = false;
-        std::vector<Eigen::VectorXd> hist_X;
-        std::vector<int> hist_cg_iter;
+    double ils_tol = 1e-3;
+    int ils_max_iter = 10;
+    int ils_min_iter = 2;
+    double ils_sigma = 1e-4;
+    double ils_tik_lam = 1e-4;
 
-        // Iteration counter (was on GroptParams)
-        int iiter = 0;
+    bool extra_debug = false;
+    DebugSolver debug_solver;
 
-        Solver() = default;
-        ~Solver() = default;
+    std::vector<int> hist_cg_iter;
 
-        virtual SolveResult solve(GroptParams &_gparams);
-        virtual int logger(Eigen::VectorXd &X);
-        virtual void final_log(Eigen::VectorXd &X, SolveResult &result);
-        virtual void set_general_params(int min_iter, int max_iter, int log_interval, double gamma_x, int max_feval);
-        virtual void set_ils_params(double ils_tol, int ils_max_iter, int ils_min_iter, double ils_sigma, double ils_tik_lam);
-    };
+    // Iteration counter (was on GroptParams)
+    int iiter = 0;
+
+    Solver() = default;
+    ~Solver() = default;
+
+    virtual SolveResult solve(GroptParams &_gparams);
+    virtual int logger(Eigen::VectorXd &X);
+    virtual void final_log(Eigen::VectorXd &X, SolveResult &result);
+    virtual void set_general_params(int min_iter, int max_iter, int log_interval, double gamma_x, int max_feval);
+    virtual void set_ils_params(double ils_tol, int ils_max_iter, int ils_min_iter, double ils_sigma,
+                                double ils_tik_lam);
+};
 
 } // namespace Gropt
 

--- a/gropt/src/solver.hpp
+++ b/gropt/src/solver.hpp
@@ -39,6 +39,7 @@ class Solver {
     int log_interval = 20;
     int min_iter = 0;
     double gamma_x = 1.6;
+    int extra_iters = 0;
 
     double ils_tol = 1e-3;
     int ils_max_iter = 10;
@@ -60,7 +61,8 @@ class Solver {
     virtual SolveResult solve(GroptParams &_gparams);
     virtual int logger(Eigen::VectorXd &X);
     virtual void final_log(Eigen::VectorXd &X, SolveResult &result);
-    virtual void set_general_params(int min_iter, int max_iter, int log_interval, double gamma_x, int max_feval);
+    virtual void set_general_params(int min_iter, int max_iter, int log_interval, double gamma_x, int max_feval,
+                                    int extra_iters);
     virtual void set_ils_params(double ils_tol, int ils_max_iter, int ils_min_iter, double ils_sigma,
                                 double ils_tik_lam);
 };

--- a/gropt/src/solver_groptsdmm.cpp
+++ b/gropt/src/solver_groptsdmm.cpp
@@ -93,6 +93,13 @@ SolveResult SolverGroptSDMM::solve(GroptParams &_gparams) {
         }
 
         if ((logger(X) > 0) && (iiter > min_iter)) {
+            if (extra_iters > 0) {
+                spdlog::info("First dsolved at iiter {:d}, now {:d} extra iterations", iiter, extra_iters);
+                min_iter = iiter + extra_iters;
+                extra_iters = 0;
+            } else {
+                break;
+            }
             break;
         }
 

--- a/gropt/src/solver_groptsdmm.cpp
+++ b/gropt/src/solver_groptsdmm.cpp
@@ -112,7 +112,6 @@ SolveResult SolverGroptSDMM::solve(GroptParams &_gparams) {
     delete ils_solver;
     spdlog::trace("Finished SolverGroptSDMM::solve");
 
-    last_result = result;
     return result;
 }
 
@@ -181,11 +180,6 @@ void SolverGroptSDMM::set_sdmm_params(int rw_interval, double rw_e_corr, double 
     this->grw_min_infeasible = grw_min_infeasible;
     this->grw_interval = grw_interval;
     this->grw_mod = grw_mod;
-}
-
-void SolverGroptSDMM::get_result_X(double **out, int &out_size) {
-    out_size = last_result.X.size();
-    *out = last_result.X.data();
 }
 
 } // namespace Gropt

--- a/gropt/src/solver_groptsdmm.cpp
+++ b/gropt/src/solver_groptsdmm.cpp
@@ -1,15 +1,14 @@
 #include "spdlog/spdlog.h"
 
 #include "ils.hpp"
+#include "ils_bicgstabl.hpp"
 #include "ils_cg.hpp"
 #include "ils_nlcg.hpp"
-#include "ils_bicgstabl.hpp"
 #include "solver_groptsdmm.hpp"
 
 namespace Gropt {
 
-SolveResult SolverGroptSDMM::solve(GroptParams &_gparams)
-{
+SolveResult SolverGroptSDMM::solve(GroptParams &_gparams) {
     spdlog::trace("Starting SolverGroptSDMM::solve");
     gparams = &_gparams;
     if (gparams->op_prep_status != gparams->N) {
@@ -25,8 +24,8 @@ SolveResult SolverGroptSDMM::solve(GroptParams &_gparams)
         // Set initial weight based on operator type
         sdmm_ws[i].weight = 1.0;
         // Slew, moment, bvalue, SAFE, TV operators start with higher weight
-        if (op->name == "Slew" || op->name == "Moment" || op->name == "b-value" ||
-            op->name == "SAFE" || op->name == "TotalVariation") {
+        if (op->name == "Slew" || op->name == "Moment" || op->name == "b-value" || op->name == "SAFE" ||
+            op->name == "TotalVariation") {
             sdmm_ws[i].weight = 1e4;
         }
         sdmm_ws[i].weight *= op->weight_mod;
@@ -87,16 +86,19 @@ SolveResult SolverGroptSDMM::solve(GroptParams &_gparams)
 
         get_residuals(X);
 
-        if (extra_debug) {hist_X.push_back(X);}
+        if (extra_debug) {
+            debug_solver.hist_X.push_back(X);
+        }
 
-        if ((logger(X) > 0) && (iiter > min_iter)) {break;}
+        if ((logger(X) > 0) && (iiter > min_iter)) {
+            break;
+        }
 
         total_feval += ils_solver->hist_n_iter.back();
         if (total_feval > max_feval) {
             spdlog::info("Maximum function evaluations reached");
             break;
         }
-
     }
 
     SolveResult result;
@@ -111,8 +113,7 @@ SolveResult SolverGroptSDMM::solve(GroptParams &_gparams)
     return result;
 }
 
-void SolverGroptSDMM::update(Eigen::VectorXd &X)
-{
+void SolverGroptSDMM::update(Eigen::VectorXd &X) {
     spdlog::trace("Starting SolverGroptSDMM::update");
 
     for (int i = 0; i < gparams->all_op.size(); i++) {
@@ -129,7 +130,7 @@ void SolverGroptSDMM::update(Eigen::VectorXd &X)
         // y = y0 + p*(as + (1-a)z0 - z1)
         w.y1 = w.y0 + w.weight * (w.gamma * w.s1 + (1 - w.gamma) * w.z0 - w.z1);
 
-        if ((w.do_rw) && (iiter > rw_interval) && (iiter%rw_interval == 0)) {
+        if ((w.do_rw) && (iiter > rw_interval) && (iiter % rw_interval == 0)) {
             w.reweight(rw_eps, rw_e_corr, rw_scalelim);
         }
 
@@ -140,8 +141,7 @@ void SolverGroptSDMM::update(Eigen::VectorXd &X)
     spdlog::trace("Finished SolverGroptSDMM::update");
 }
 
-void SolverGroptSDMM::get_residuals(Eigen::VectorXd &X)
-{
+void SolverGroptSDMM::get_residuals(Eigen::VectorXd &X) {
     // Update feasibility metrics
     for (int i = 0; i < gparams->all_op.size(); i++) {
         Operator *op = gparams->all_op[i].get();
@@ -150,12 +150,12 @@ void SolverGroptSDMM::get_residuals(Eigen::VectorXd &X)
         op->check(op->Ax_temp);
     }
 
-
-    if (iiter > 2*grw_min_infeasible && iiter % grw_interval == 0) {
+    if (iiter > 2 * grw_min_infeasible && iiter % grw_interval == 0) {
         double max_feas = 0.0;
         int max_index = -1;
         for (int i = 0; i < gparams->all_op.size(); i++) {
-            if (std::accumulate(gparams->all_op[i]->hist_feas.end()-grw_min_infeasible, gparams->all_op[i]->hist_feas.end(), 0) == 0) {
+            if (std::accumulate(gparams->all_op[i]->hist_feas.end() - grw_min_infeasible,
+                                gparams->all_op[i]->hist_feas.end(), 0) == 0) {
                 if (gparams->all_op[i]->hist_r_feas.back() > max_feas) {
                     max_feas = gparams->all_op[i]->hist_r_feas.back();
                     max_index = i;
@@ -166,13 +166,10 @@ void SolverGroptSDMM::get_residuals(Eigen::VectorXd &X)
             sdmm_ws[max_index].weight *= grw_mod;
         }
     }
-
-
 }
 
 void SolverGroptSDMM::set_sdmm_params(int rw_interval, double rw_e_corr, double rw_eps, double rw_scalelim,
-                             int grw_min_infeasible, int grw_interval, double grw_mod)
-{
+                                      int grw_min_infeasible, int grw_interval, double grw_mod) {
     this->rw_interval = rw_interval;
     this->rw_e_corr = rw_e_corr;
     this->rw_eps = rw_eps;
@@ -183,8 +180,7 @@ void SolverGroptSDMM::set_sdmm_params(int rw_interval, double rw_e_corr, double 
     this->grw_mod = grw_mod;
 }
 
-void SolverGroptSDMM::get_result_X(double **out, int &out_size)
-{
+void SolverGroptSDMM::get_result_X(double **out, int &out_size) {
     out_size = last_result.X.size();
     *out = last_result.X.data();
 }

--- a/gropt/src/solver_groptsdmm.cpp
+++ b/gropt/src/solver_groptsdmm.cpp
@@ -94,7 +94,7 @@ SolveResult SolverGroptSDMM::solve(GroptParams &_gparams) {
 
         if ((logger(X) > 0) && (iiter > min_iter)) {
             if (extra_iters > 0) {
-                spdlog::info("First dsolved at iiter {:d}, now {:d} extra iterations", iiter, extra_iters);
+                spdlog::info("First solved at iiter {:d}, now {:d} extra iterations", iiter, extra_iters);
                 min_iter = iiter + extra_iters;
                 extra_iters = 0;
             } else {

--- a/gropt/src/solver_groptsdmm.cpp
+++ b/gropt/src/solver_groptsdmm.cpp
@@ -100,7 +100,6 @@ SolveResult SolverGroptSDMM::solve(GroptParams &_gparams) {
             } else {
                 break;
             }
-            break;
         }
 
         total_feval += ils_solver->hist_n_iter.back();

--- a/gropt/src/solver_groptsdmm.cpp
+++ b/gropt/src/solver_groptsdmm.cpp
@@ -74,8 +74,10 @@ SolveResult SolverGroptSDMM::solve(GroptParams &_gparams) {
             Xhat = X;
         }
 
-        if (Xhat.array().isNaN().any()) {
-            spdlog::error("NaN detected in Xhat at iteration {:d}. Stopping solver.", iiter);
+        // if (Xhat.array().isNaN().any()) {
+        if ((Xhat.array().abs() > 10).any()) {
+            // spdlog::error("NaN detected in Xhat at iteration {:d}. Stopping solver.", iiter);
+            spdlog::error("Large values detected in Xhat at iteration {:d}. Stopping solver.", iiter);
             break;
         };
 
@@ -104,6 +106,7 @@ SolveResult SolverGroptSDMM::solve(GroptParams &_gparams) {
     SolveResult result;
     result.X = X;
     result.n_iter = iiter;
+    result.dt = gparams->dt;
     final_log(X, result);
 
     delete ils_solver;

--- a/gropt/src/solver_groptsdmm.hpp
+++ b/gropt/src/solver_groptsdmm.hpp
@@ -37,14 +37,11 @@ namespace Gropt
         Eigen::VectorXd r_dual;
         Eigen::VectorXd r_primal;
 
-        SolveResult last_result;
-
         virtual SolveResult solve(GroptParams &_gparams);
         void update(Eigen::VectorXd &X);
         void get_residuals(Eigen::VectorXd &X);
         void set_sdmm_params(int rw_interval, double rw_e_corr, double rw_eps, double rw_scalelim,
                              int grw_min_infeasible, int grw_interval, double grw_mod);
-        void get_result_X(double **out, int &out_size);
     };
 
 } // namespace Gropt

--- a/gropt/src/solver_osqp.cpp
+++ b/gropt/src/solver_osqp.cpp
@@ -95,6 +95,13 @@ SolveResult SolverOSQP::solve(GroptParams &_gparams) {
         get_residuals(X);
 
         if ((logger(X) > 0) && (iiter > min_iter)) {
+            if (extra_iters > 0) {
+                spdlog::info("First dsolved at iiter {:d}, now {:d} extra iterations", iiter, extra_iters);
+                min_iter = iiter + extra_iters;
+                extra_iters = 0;
+            } else {
+                break;
+            }
             break;
         }
 

--- a/gropt/src/solver_osqp.cpp
+++ b/gropt/src/solver_osqp.cpp
@@ -23,12 +23,10 @@ SolveResult SolverOSQP::solve(GroptParams &_gparams) {
 
         // Set initial weight based on operator type
         osqp_ws[i].weight = 1.0;
-        if (!op->do_equil) {
-            // Slew, moment, bvalue, SAFE, TV operators start with higher weight
-            if (op->name == "Slew" || op->name == "Moment" || op->name == "b-value" || op->name == "SAFE" ||
-                op->name == "TotalVariation") {
-                osqp_ws[i].weight = 1e4;
-            }
+        // Slew, moment, bvalue, SAFE, TV operators start with higher weight
+        if (op->name == "Slew" || op->name == "Moment" || op->name == "b-value" || op->name == "SAFE" ||
+            op->name == "TotalVariation") {
+            osqp_ws[i].weight = 1e4;
         }
         osqp_ws[i].weight *= op->weight_mod;
 
@@ -69,6 +67,9 @@ SolveResult SolverOSQP::solve(GroptParams &_gparams) {
     }
     r_primal.setZero(total_Ax_size);
 
+    // ===============================================
+    //  OSQP iterations
+    // ===============================================
     int total_feval = 0;
     for (iiter = 0; iiter < max_iter; ++iiter) {
         spdlog::trace("Starting OSQP iteration {:d} SolverOSQP::solve", iiter);
@@ -90,10 +91,6 @@ SolveResult SolverOSQP::solve(GroptParams &_gparams) {
         X = gamma_x * Xhat + (1 - gamma_x) * X;
 
         get_residuals(X);
-
-        if (extra_debug) {
-            hist_X.push_back(X);
-        }
 
         if ((logger(X) > 0) && (iiter > min_iter)) {
             break;
@@ -143,6 +140,54 @@ void SolverOSQP::update(Eigen::VectorXd &X) {
 }
 
 void SolverOSQP::get_residuals(Eigen::VectorXd &X) {
+
+    //  Get dimensions (shouldn't be needed every iteration)
+    int N_rows = 0;
+    for (int i = 0; i < gparams->all_op.size(); i++) {
+        N_rows += gparams->all_op[i]->Ax_size;
+    }
+
+    int N_cols = gparams->N * gparams->Naxis;
+
+    // Calculate relevant variables for residuals
+    Eigen::VectorXd Ax;
+    Ax.setZero(N_rows);
+
+    Eigen::VectorXd z;
+    z.setZero(N_rows);
+
+    Eigen::VectorXd y;
+    y.setZero(N_rows);
+
+    Eigen::VectorXd Aty;
+    Aty.setZero(N_cols);
+
+    int row_start = 0;
+    for (int i = 0; i < gparams->all_op.size(); i++) {
+        Operator *op = gparams->all_op[i].get();
+        WorkspaceOSQP &w = osqp_ws[i];
+
+        op->Ax_temp.setZero();
+        op->forward_op(X, op->Ax_temp);
+        Ax.segment(row_start, op->Ax_size) = op->Ax_temp;
+        z.segment(row_start, op->Ax_size) = w.z1;
+        y.segment(row_start, op->Ax_size) = w.y1;
+
+        op->x_temp.setZero();
+        op->transpose_op(w.y1, op->x_temp);
+        Aty.array() += op->x_temp.array();
+
+        row_start += op->Ax_size;
+    }
+
+    if (extra_debug) {
+        debug_solver.hist_Ax.push_back(Ax);
+        debug_solver.hist_z.push_back(z);
+        debug_solver.hist_y.push_back(y);
+        debug_solver.hist_Aty.push_back(Aty);
+        debug_solver.hist_X.push_back(X);
+    }
+
     // Update feasibility metrics
     for (int i = 0; i < gparams->all_op.size(); i++) {
         Operator *op = gparams->all_op[i].get();

--- a/gropt/src/solver_osqp.cpp
+++ b/gropt/src/solver_osqp.cpp
@@ -114,7 +114,6 @@ SolveResult SolverOSQP::solve(GroptParams &_gparams) {
     delete ils_solver;
     spdlog::trace("Finished SolverOSQP::solve");
 
-    last_result = result;
     return result;
 }
 
@@ -259,11 +258,6 @@ void SolverOSQP::get_residuals(Eigen::VectorXd &X) {
         op->get_feas(op->Ax_temp);
         op->check(op->Ax_temp);
     }
-}
-
-void SolverOSQP::get_result_X(double **out, int &out_size) {
-    out_size = last_result.X.size();
-    *out = last_result.X.data();
 }
 
 } // namespace Gropt

--- a/gropt/src/solver_osqp.cpp
+++ b/gropt/src/solver_osqp.cpp
@@ -96,13 +96,12 @@ SolveResult SolverOSQP::solve(GroptParams &_gparams) {
 
         if ((logger(X) > 0) && (iiter > min_iter)) {
             if (extra_iters > 0) {
-                spdlog::info("First dsolved at iiter {:d}, now {:d} extra iterations", iiter, extra_iters);
+                spdlog::info("First solved at iiter {:d}, now {:d} extra iterations", iiter, extra_iters);
                 min_iter = iiter + extra_iters;
                 extra_iters = 0;
             } else {
                 break;
             }
-            break;
         }
 
         total_feval += ils_solver->hist_n_iter.back();

--- a/gropt/src/solver_osqp.cpp
+++ b/gropt/src/solver_osqp.cpp
@@ -80,8 +80,10 @@ SolveResult SolverOSQP::solve(GroptParams &_gparams) {
             Xhat = X;
         }
 
-        if (Xhat.array().isNaN().any()) {
-            spdlog::error("NaN detected in Xhat at iteration {:d}. Stopping solver.", iiter);
+        // if (Xhat.array().isNaN().any()) {
+        if ((Xhat.array().abs() > 10).any()) {
+            // spdlog::error("NaN detected in Xhat at iteration {:d}. Stopping solver.", iiter);
+            spdlog::error("Large values detected in Xhat at iteration {:d}. Stopping solver.", iiter);
             break;
         };
 
@@ -106,6 +108,7 @@ SolveResult SolverOSQP::solve(GroptParams &_gparams) {
     SolveResult result;
     result.X = X;
     result.n_iter = iiter;
+    result.dt = gparams->dt;
     final_log(X, result);
 
     delete ils_solver;
@@ -117,6 +120,11 @@ SolveResult SolverOSQP::solve(GroptParams &_gparams) {
 
 void SolverOSQP::update(Eigen::VectorXd &X) {
     spdlog::trace("Starting SolverOSQP::update");
+
+    double max_scale = 2.0;
+    Eigen::VectorXd all_weight_scale;
+    all_weight_scale.setZero(gparams->all_op.size());
+    bool needs_reweight = false;
 
     for (int i = 0; i < gparams->all_op.size(); i++) {
         Operator *op = gparams->all_op[i].get();
@@ -134,6 +142,49 @@ void SolverOSQP::update(Eigen::VectorXd &X) {
 
         w.y0 = w.y1;
         w.z0 = w.z1;
+
+        if (iiter == 2) {
+            w.init_reweight();
+        } else if ((iiter > 5) && (iiter % 50 == 0)) {
+            w.reweight(iiter, max_scale, max_scale, 1.0e-8);
+            needs_reweight = true;
+        }
+        all_weight_scale(i) = w.weight_scale;
+    }
+
+    if (needs_reweight) {
+
+        std::ostringstream oss;
+        oss << "ReWeights: ";
+        for (int i = 0; i < gparams->all_op.size(); i++) {
+            oss << all_weight_scale(i) << " ";
+        }
+        // spdlog::info("{:d}  {}", iiter, oss.str());
+
+        if ((all_weight_scale.array() >= max_scale).all()) {
+            // spdlog::warn("All weight scales above max_scale., scaling to max");
+            // all_weight_scale = all_weight_scale / all_weight_scale.maxCoeff();
+            all_weight_scale.setOnes();
+
+            oss.str("");
+            oss << "Re-ReWeights: ";
+            for (int i = 0; i < gparams->all_op.size(); i++) {
+                oss << all_weight_scale(i) << " ";
+            }
+            // spdlog::info("{:d}  {}", iiter, oss.str());
+        }
+
+        for (int i = 0; i < gparams->all_op.size(); i++) {
+            Operator *op = gparams->all_op[i].get();
+            WorkspaceOSQP &w = osqp_ws[i];
+
+            if (all_weight_scale(i) > max_scale) {
+                all_weight_scale(i) = max_scale;
+            } else if (all_weight_scale(i) < 1.0 / max_scale) {
+                all_weight_scale(i) = 1.0 / max_scale;
+            }
+            w.weight *= all_weight_scale(i);
+        }
     }
 
     spdlog::trace("Finished SolverOSQP::update");
@@ -186,6 +237,19 @@ void SolverOSQP::get_residuals(Eigen::VectorXd &X) {
         debug_solver.hist_y.push_back(y);
         debug_solver.hist_Aty.push_back(Aty);
         debug_solver.hist_X.push_back(X);
+
+        std::vector<double> weight_vec;
+        std::vector<double> gamma_vec;
+        for (int i = 0; i < gparams->all_op.size(); i++) {
+            Operator *op = gparams->all_op[i].get();
+            WorkspaceOSQP &w = osqp_ws[i];
+            weight_vec.push_back(w.weight);
+            gamma_vec.push_back(w.gamma);
+        }
+        debug_solver.hist_weight.push_back(weight_vec);
+        debug_solver.hist_gamma.push_back(gamma_vec);
+
+        debug_solver.hist_gamma_x.push_back(gamma_x);
     }
 
     // Update feasibility metrics

--- a/gropt/src/solver_osqp.hpp
+++ b/gropt/src/solver_osqp.hpp
@@ -28,12 +28,9 @@ namespace Gropt
         Eigen::VectorXd r_dual;
         Eigen::VectorXd r_primal;
 
-        SolveResult last_result;
-
         virtual SolveResult solve(GroptParams &_gparams);
         void update(Eigen::VectorXd &X);
         void get_residuals(Eigen::VectorXd &X);
-        void get_result_X(double **out, int &out_size);
     };
 
 } // namespace Gropt

--- a/gropt/src/workspace_osqp.cpp
+++ b/gropt/src/workspace_osqp.cpp
@@ -1,2 +1,61 @@
 #include "workspace_osqp.hpp"
-// WorkspaceOSQP is an alias for WorkspaceSolver; all implementations are in workspace_solver.cpp
+#include "op_main.hpp"
+
+namespace Gropt {
+
+void WorkspaceOSQP::init(int Ax_size) {
+    WorkspaceSolver::init(Ax_size);
+
+    y00.setZero(Ax_size);
+    z00.setZero(Ax_size);
+}
+
+void WorkspaceOSQP::reinit(int Ax_size) {
+    WorkspaceSolver::reinit(Ax_size);
+
+    if (y00.size() != Ax_size) {
+        y00.setZero(Ax_size);
+    }
+
+    z00.setZero(Ax_size);
+}
+
+void WorkspaceOSQP::prep(Operator &op, const Eigen::VectorXd &X) {
+    WorkspaceSolver::prep(op, X);
+    z00 = z0;
+}
+
+void WorkspaceOSQP::init_reweight() {
+    y00 = y0;
+    z00 = z0;
+}
+
+void WorkspaceOSQP::reweight(int iiter, double scale_up, double scale_down, double eps) {
+    double p = (y00 - y0).norm();
+    double q = (z00 - z0).norm();
+
+    if ((p < eps) && (q >= eps)) {
+        weight_scale = 1 / scale_down;
+    } else if ((p >= eps) && (q < eps)) {
+        weight_scale = scale_up;
+    } else if ((p >= eps) && (q >= eps)) {
+        double new_weight = p / q;
+        weight_scale = new_weight / weight;
+    } else {
+        weight_scale = 1.0;
+    }
+
+    // double max_exponent = std::log(1.0 + iiter);
+    // max_exponent = pow(10.0, max_exponent);
+
+    // if (weight > max_exponent) {
+    //     weight = max_exponent;
+    // } else if (weight < 1.0 / max_exponent) {
+    //     weight = 1.0 / max_exponent;
+    // }
+
+    y00 = y0;
+    z00 = z0;
+}
+
+} // namespace Gropt

--- a/gropt/src/workspace_osqp.hpp
+++ b/gropt/src/workspace_osqp.hpp
@@ -5,10 +5,17 @@
 
 namespace Gropt {
 
-// WorkspaceOSQP uses the same per-operator state as the base WorkspaceSolver.
-// It can be extended here if OSQP-specific state is needed in the future.
-using WorkspaceOSQP = WorkspaceSolver;
+struct WorkspaceOSQP : WorkspaceSolver {
+    Eigen::VectorXd y00, z00;
+    double weight_scale = 1.0;
 
-}  // namespace Gropt
+    void init(int Ax_size);
+    void reinit(int Ax_size);
+    void prep(Operator &op, const Eigen::VectorXd &X);
+    void init_reweight();
+    void reweight(int iiter, double scale_up, double scale_down, double eps);
+};
+
+} // namespace Gropt
 
 #endif

--- a/gropt/src/workspace_sdmm.cpp
+++ b/gropt/src/workspace_sdmm.cpp
@@ -3,8 +3,7 @@
 
 namespace Gropt {
 
-void WorkspaceSDMM::init(int Ax_size)
-{
+void WorkspaceSDMM::init(int Ax_size) {
     WorkspaceSolver::init(Ax_size);
 
     yhat1.setZero(Ax_size);
@@ -19,12 +18,15 @@ void WorkspaceSDMM::init(int Ax_size)
     z00.setZero(Ax_size);
 }
 
-void WorkspaceSDMM::reinit(int Ax_size)
-{
+void WorkspaceSDMM::reinit(int Ax_size) {
     WorkspaceSolver::reinit(Ax_size);
 
-    if (yhat00.size() != Ax_size) { yhat00.setZero(Ax_size); }
-    if (y00.size() != Ax_size)    { y00.setZero(Ax_size); }
+    if (yhat00.size() != Ax_size) {
+        yhat00.setZero(Ax_size);
+    }
+    if (y00.size() != Ax_size) {
+        y00.setZero(Ax_size);
+    }
 
     yhat1.setZero(Ax_size);
     dyhat.setZero(Ax_size);
@@ -36,44 +38,38 @@ void WorkspaceSDMM::reinit(int Ax_size)
     z00.setZero(Ax_size);
 }
 
-void WorkspaceSDMM::prep(Operator &op, const Eigen::VectorXd &X)
-{
+void WorkspaceSDMM::prep(Operator &op, const Eigen::VectorXd &X) {
     WorkspaceSolver::prep(op, X);
     z00 = z0;
 }
 
-void WorkspaceSDMM::reweight(double rw_eps, double e_corr, double rw_scalelim)
-{
+void WorkspaceSDMM::reweight(double rw_eps, double e_corr, double rw_scalelim) {
     double rho0 = weight;
 
-    yhat1.array() = y0.array() + rho0*(s1.array() - z1.array());
+    yhat1.array() = y0.array() + rho0 * (s1.array() - z1.array());
 
     dyhat.array() = (yhat1.array() - yhat00.array());
     dy.array() = -(y1.array() - y00.array());
     dhhat.array() = s1.array() - s00.array();
     dghat.array() = -(z1.array() - z00.array());
 
-    double norm_dhhat_dyhat = dhhat.norm()*dyhat.norm();
+    double norm_dhhat_dyhat = dhhat.norm() * dyhat.norm();
     double dot_dhhat_dhhat = dhhat.dot(dhhat);
     double dot_dhhat_dyhat = dhhat.dot(dyhat);
 
     double alpha_corr = 0.0;
-    if ((norm_dhhat_dyhat > rw_eps)
-        && (dot_dhhat_dhhat > rw_eps)
-        && (dot_dhhat_dyhat > rw_eps)) {
-            alpha_corr = dot_dhhat_dyhat/norm_dhhat_dyhat;
-        }
+    if ((norm_dhhat_dyhat > rw_eps) && (dot_dhhat_dhhat > rw_eps) && (dot_dhhat_dyhat > rw_eps)) {
+        alpha_corr = dot_dhhat_dyhat / norm_dhhat_dyhat;
+    }
 
-    double norm_dghat_dy = dghat.norm()*dy.norm();
+    double norm_dghat_dy = dghat.norm() * dy.norm();
     double dot_dghat_dghat = dghat.dot(dghat);
     double dot_dghat_dy = dghat.dot(dy);
 
     double beta_corr = 0.0;
-    if ((norm_dghat_dy > rw_eps)
-        && (dot_dghat_dghat > rw_eps)
-        && (dot_dghat_dy > rw_eps)) {
-            beta_corr = dot_dghat_dy/norm_dghat_dy;
-        }
+    if ((norm_dghat_dy > rw_eps) && (dot_dghat_dghat > rw_eps) && (dot_dghat_dy > rw_eps)) {
+        beta_corr = dot_dghat_dy / norm_dghat_dy;
+    }
 
     bool pass_alpha = false;
     bool pass_beta = false;
@@ -81,32 +77,32 @@ void WorkspaceSDMM::reweight(double rw_eps, double e_corr, double rw_scalelim)
     double alpha = 0.0;
     if (alpha_corr > e_corr) {
         pass_alpha = true;
-        double alpha_mg = dot_dhhat_dyhat/dot_dhhat_dhhat;
-        double alpha_sd = dyhat.dot(dyhat)/dot_dhhat_dyhat;
-        if (2.0*alpha_mg > alpha_sd) {
+        double alpha_mg = dot_dhhat_dyhat / dot_dhhat_dhhat;
+        double alpha_sd = dyhat.dot(dyhat) / dot_dhhat_dyhat;
+        if (2.0 * alpha_mg > alpha_sd) {
             alpha = alpha_mg;
         } else {
-            alpha = alpha_sd - 0.5*alpha_mg;
+            alpha = alpha_sd - 0.5 * alpha_mg;
         }
     }
 
     double beta = 0.0;
     if (beta_corr > e_corr) {
         pass_beta = true;
-        double beta_mg = dot_dghat_dy/dot_dghat_dghat;
-        double beta_sd = dy.dot(dy)/dot_dghat_dy;
-        if (2.0*beta_mg > beta_sd) {
+        double beta_mg = dot_dghat_dy / dot_dghat_dghat;
+        double beta_sd = dy.dot(dy) / dot_dghat_dy;
+        if (2.0 * beta_mg > beta_sd) {
             beta = beta_mg;
         } else {
-            beta = beta_sd - 0.5*beta_mg;
+            beta = beta_sd - 0.5 * beta_mg;
         }
     }
 
     double step_g1 = 0.0;
     double gamma1 = 0.0;
     if ((pass_alpha == true) && (pass_beta == true)) {
-        step_g1 = sqrt(alpha*beta);
-        gamma1 = 1.0 + 2.0*sqrt(alpha*beta)/(alpha+beta);
+        step_g1 = sqrt(alpha * beta);
+        gamma1 = 1.0 + 2.0 * sqrt(alpha * beta) / (alpha + beta);
     } else if ((pass_alpha == true) && (pass_beta == false)) {
         step_g1 = alpha;
         gamma1 = 1.9;
@@ -119,10 +115,10 @@ void WorkspaceSDMM::reweight(double rw_eps, double e_corr, double rw_scalelim)
     }
 
     if (do_weight == true) {
-        if ((do_scalelim == true) && (step_g1 > rw_scalelim*weight)) {
+        if ((do_scalelim == true) && (step_g1 > rw_scalelim * weight)) {
             weight *= rw_scalelim;
-        } else if ((do_scalelim == true) && (rw_scalelim*step_g1 < weight)) {
-            weight *= 1.0/rw_scalelim;
+        } else if ((do_scalelim == true) && (rw_scalelim * step_g1 < weight)) {
+            weight *= 1.0 / rw_scalelim;
         } else {
             weight = step_g1;
         }
@@ -138,4 +134,4 @@ void WorkspaceSDMM::reweight(double rw_eps, double e_corr, double rw_scalelim)
     z00 = z1;
 }
 
-}  // namespace Gropt
+} // namespace Gropt

--- a/gropt/src/workspace_solver.cpp
+++ b/gropt/src/workspace_solver.cpp
@@ -3,8 +3,7 @@
 
 namespace Gropt {
 
-void WorkspaceSolver::init(int Ax_size)
-{
+void WorkspaceSolver::init(int Ax_size) {
     y0.setZero(Ax_size);
     y1.setZero(Ax_size);
     z0.setZero(Ax_size);
@@ -13,21 +12,27 @@ void WorkspaceSolver::init(int Ax_size)
     s1.setZero(Ax_size);
 }
 
-void WorkspaceSolver::reinit(int Ax_size)
-{
-    if (y0.size() != Ax_size) { y0.setZero(Ax_size); }
-    if (y1.size() != Ax_size) { y1.setZero(Ax_size); }
-    if (s0.size() != Ax_size) { s0.setZero(Ax_size); }
-    if (s1.size() != Ax_size) { s1.setZero(Ax_size); }
+void WorkspaceSolver::reinit(int Ax_size) {
+    if (y0.size() != Ax_size) {
+        y0.setZero(Ax_size);
+    }
+    if (y1.size() != Ax_size) {
+        y1.setZero(Ax_size);
+    }
+    if (s0.size() != Ax_size) {
+        s0.setZero(Ax_size);
+    }
+    if (s1.size() != Ax_size) {
+        s1.setZero(Ax_size);
+    }
     z0.setZero(Ax_size);
     z1.setZero(Ax_size);
 }
 
-void WorkspaceSolver::prep(Operator &op, const Eigen::VectorXd &X)
-{
-    Eigen::VectorXd X_copy = X;  // forward_op takes non-const ref
+void WorkspaceSolver::prep(Operator &op, const Eigen::VectorXd &X) {
+    Eigen::VectorXd X_copy = X; // forward_op takes non-const ref
     op.forward_op(X_copy, z0);
     z1 = z0;
 }
 
-}  // namespace Gropt
+} // namespace Gropt

--- a/pixi.lock
+++ b/pixi.lock
@@ -3,31 +3,39 @@ environments:
   default:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
-    indexes:
-    - https://pypi.org/simple
     options:
       pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_8.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.8.3-h4c7d964_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.11.0-5_hf2e6a31_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.11.0-5_h2a3cdd5_mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.7.4-hac47afa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.6-h537db12_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.12.2-default_h4379cf1_1000.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.18-hc1393d2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.11.0-5_hf9ab0e9_mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.2-hfd05255_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libmpdec-4.0.0-h2466b09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.50.4-hf5d6505_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libwinpthread-12.0.0.r4.gg4f2fc60ca-h57928b3_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-16-2.15.2-h692994f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.15.2-h5d26750_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/llvm-openmp-22.1.0-h4fa8253_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2025.3.0-hac47afa_455.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.4.2-py313hce7ae62_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.5.2-h725018a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.13.7-hdf00ec1_100_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2022.3.0-h3155e25_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h2c6b04d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h41ae7f8_31.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_31.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.44.35208-h818238b_31.conda
-      - pypi: https://files.pythonhosted.org/packages/1b/b5/263ebbbbcede85028f30047eab3d58028d7ebe389d6493fc95ae66c636ab/numpy-2.3.3-cp313-cp313-win_amd64.whl
-      - pypi: ./
   dev:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -45,16 +53,27 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-resources-6.5.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.5.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.3-hdf4eb48_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.11.0-5_hf2e6a31_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.11.0-5_h2a3cdd5_mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.18.0-h43ecb02_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.7.4-hac47afa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.6-h537db12_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.12.2-default_h4379cf1_1000.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.18-hc1393d2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.11.0-5_hf9ab0e9_mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.2-hfd05255_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libmpdec-4.0.0-h2466b09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.50.4-hf5d6505_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.1-h9aa295b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libuv-1.51.0-hfd05255_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libwinpthread-12.0.0.r4.gg4f2fc60ca-h57928b3_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-16-2.15.2-h692994f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.15.2-h5d26750_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/llvm-openmp-22.1.0-h4fa8253_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2025.3.0-hac47afa_455.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nanobind-2.10.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.4.2-py313hce7ae62_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.5.2-h725018a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.0.4-pyhd8ed1ab_0.conda
@@ -62,6 +81,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.13.7-hdf00ec1_100_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/scikit-build-core-0.11.6-pyh7e86bf3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2022.3.0-h3155e25_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h2c6b04d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
@@ -112,6 +132,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fc/c7/b445faca8deb954fe536abebff4ece5b097b923de482b26e78448c89d1dd/ipykernel-6.30.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/08/2a/5628a99d04acb2d2f2e749cdf4ea571d2575e898df0528a090948018b726/ipython-9.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d9/33/1f075bf72b0b747cb3288d011319aaf64083cf2efef8354174e3ed4540e2/ipython_pygments_lexers-1.1.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/56/6d/0d9848617b9f753b87f214f1c682592f7ca42de085f564352f10f0843026/ipywidgets-8.1.8-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7b/55/e5326141505c5d5e34c5e0935d2908a74e4561eca44108fbfb9c13d2911a/isoduration-20.11.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ff/db/0c52c4cf5e4bd9f5d7135ec7669a3a767af21b3a308e1ed3674881e52b62/jaraco.context-6.0.1-py3-none-any.whl
@@ -131,6 +152,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/7e/01/44f35124896dd5c73b26705c25bb8af2089895b32f057a1e4a3488847333/jupyterlab-4.4.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b1/dd/ead9d8ea85bf202d90cc513b533f9c363121c7792674f78e0d8a854b63b4/jupyterlab_pygments-0.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/54/09/2032e7d15c544a0e3cd831c51d77a8ca57f7555b2e1b2922142eddb02a84/jupyterlab_server-2.27.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ab/b5/36c712098e6191d1b4e349304ef73a8d06aed77e56ceaac8c0a306c7bda1/jupyterlab_widgets-3.0.16-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/36/86/751ec86adb66104d15e650b704f89dddd64ba29283178b9651b9bc84b624/jupytext-1.17.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d3/32/da7f44bcb1105d3e88a0b74ebdca50c59121d2ddf71c9e34ba47df7f3a56/keyring-25.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/75/bd/f1a5d894000941739f2ae1b65a32892349423ad49c2e6d0771d0bad3fae4/kiwisolver-1.4.9-cp313-cp313-win_amd64.whl
@@ -161,12 +183,11 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8c/ae/324b165d904dc1672eee5f5661c0a68d4bab5b59fbb07afb6d8d19a30b45/nh3-0.3.0-cp38-abi3-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/f9/33/bd5b9137445ea4b680023eb0469b2bb969d61303dedb2aac6560ff3d14a1/notebook_shim-0.2.4-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/1b/b5/263ebbbbcede85028f30047eab3d58028d7ebe389d6493fc95ae66c636ab/numpy-2.3.3-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/90/96/04b8e52da071d28f5e21a805b19cb9390aa17a47462ac87f5e2696b9566d/paginate-0.5.7-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/22/3c/f2af1ce8840ef648584a6156489636b5692c162771918aa95707c165ad2b/pandas-2.3.2-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/ef/af/4fbc8cab944db5d21b7e2a5b8e9211a03a79852b1157e2c102fcc61ac440/pandocfilters-1.5.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/16/32/f8e3c85d1d5250232a5d3477a2a28cc291968ff175caeadaf3cc19ce0e4a/parso-0.8.5-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/23/85/397c73524e0cd212067e0c969aa245b01d50183439550d24d9f55781b776/pillow-11.3.0-cp313-cp313-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/3f/eb/b0834ad8b583d7d9d42b80becff092082a1c3c156bb582590fcc973f1c7c/pillow-12.1.1-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/40/4b/2028861e724d3bd36227adfa20d3fd24c3fc6d52032f4a93c133be5d17ce/platformdirs-4.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/32/ae/ec06af4fe3ee72d16973474f122541746196aaa16cea6f66d18b963c6177/prometheus_client-0.22.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl
@@ -197,7 +218,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/7e/71/44ce230e1b7fadd372515a97e32a83011f906ddded8d03e3c6aafbdedbb7/rfc3987_syntax-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e3/30/3c4d035596d3cf444529e0b2953ad0466f6049528a879d27534700580395/rich-14.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ce/2c/5867b14a81dc217b56d95a9f2a40fdbc56a1ab0181b80132beeecbd4b2d6/rpds_py-0.27.1-cp313-cp313-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/21/12/c0efd2941f01940119b5305c375ae5c0fcb7ec193f806bd8f158b73a1782/scipy-1.16.1-cp313-cp313-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/35/e5/d6d0e51fc888f692a35134336866341c08655d92614f492c6860dc45bb2c/scipy-1.17.1-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/83/11/00d3c3dfc25ad54e731d91449895a79e4bf2384dc3ac01809010ba88f6d5/seaborn-0.13.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/40/b0/4562db6223154aa4e22f939003cb92514c79f3d4dccca3444253fd17f902/Send2Trash-1.8.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e1/c6/76dc613121b793286a3f91621d7b75a2b493e0390ddca50f11993eadf192/setuptools-82.0.0-py3-none-any.whl
@@ -222,7 +243,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5a/84/44687a29792a70e111c5c477230a72c4b957d88d16141199bf9acb7537a3/websocket_client-1.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0b/2c/87f3254fd8ffd29e4c02732eee68a83a1d3c346ae39bc6822dcbcb697f2b/wheel-0.45.1-py3-none-any.whl
-      - pypi: ./
+      - pypi: https://files.pythonhosted.org/packages/3f/0e/fa3b193432cfc60c93b42f3be03365f5f909d2b3ea410295cf36df739e31/widgetsnbextension-4.0.15-py3-none-any.whl
 packages:
 - pypi: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
   name: annotated-types
@@ -617,25 +638,6 @@ packages:
   requires_dist:
   - colorama>=0.4
   requires_python: '>=3.9'
-- pypi: ./
-  name: gropt
-  version: 2.0.0rc9
-  sha256: daf53abcf42f25d8bd20748b5a568c717197b72cc5bb0affc1047a66c6076ff6
-  requires_dist:
-  - numpy
-  - pyqt6 ; extra == 'gui'
-  - matplotlib ; extra == 'gui'
-  - jupyterlab ; extra == 'dev'
-  - wheel ; extra == 'dev'
-  - scipy ; extra == 'dev'
-  - twine ; extra == 'dev'
-  - seaborn ; extra == 'dev'
-  - mkdocs ; extra == 'docs'
-  - mkdocs-material ; extra == 'docs'
-  - mkdocs-jupyter ; extra == 'docs'
-  - mkdocstrings-python ; extra == 'docs'
-  - mkdocs-awesome-nav ; extra == 'docs'
-  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl
   name: h11
   version: 0.16.0
@@ -830,6 +832,22 @@ packages:
   requires_dist:
   - pygments
   requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/56/6d/0d9848617b9f753b87f214f1c682592f7ca42de085f564352f10f0843026/ipywidgets-8.1.8-py3-none-any.whl
+  name: ipywidgets
+  version: 8.1.8
+  sha256: ecaca67aed704a338f88f67b1181b58f821ab5dc89c1f0f5ef99db43c1c2921e
+  requires_dist:
+  - comm>=0.1.3
+  - ipython>=6.1.0
+  - traitlets>=4.3.1
+  - widgetsnbextension~=4.0.14
+  - jupyterlab-widgets~=3.0.15
+  - jsonschema ; extra == 'test'
+  - ipykernel ; extra == 'test'
+  - pytest>=3.6.0 ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  - pytz ; extra == 'test'
+  requires_python: '>=3.7'
 - pypi: https://files.pythonhosted.org/packages/7b/55/e5326141505c5d5e34c5e0935d2908a74e4561eca44108fbfb9c13d2911a/isoduration-20.11.0-py3-none-any.whl
   name: isoduration
   version: 20.11.0
@@ -1260,6 +1278,11 @@ packages:
   - strict-rfc3339 ; extra == 'test'
   - werkzeug ; extra == 'test'
   requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/ab/b5/36c712098e6191d1b4e349304ef73a8d06aed77e56ceaac8c0a306c7bda1/jupyterlab_widgets-3.0.16-py3-none-any.whl
+  name: jupyterlab-widgets
+  version: 3.0.16
+  sha256: 45fa36d9c6422cf2559198e4db481aa243c7a32d9926b500781c830c80f7ecf8
+  requires_python: '>=3.7'
 - pypi: https://files.pythonhosted.org/packages/36/86/751ec86adb66104d15e650b704f89dddd64ba29283178b9651b9bc84b624/jupytext-1.17.3-py3-none-any.whl
   name: jupytext
   version: 1.17.3
@@ -1395,6 +1418,37 @@ packages:
   - js2py ; extra == 'nearley'
   - regex ; extra == 'regex'
   requires_python: '>=3.8'
+- conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.11.0-5_hf2e6a31_mkl.conda
+  build_number: 5
+  sha256: f0cb7b2697461a306341f7ff32d5b361bb84f3e94478464c1e27ee01fc8f276b
+  md5: f9decf88743af85c9c9e05556a4c47c0
+  depends:
+  - mkl >=2025.3.0,<2026.0a0
+  constrains:
+  - liblapack  3.11.0   5*_mkl
+  - libcblas   3.11.0   5*_mkl
+  - blas 2.305   mkl
+  - liblapacke 3.11.0   5*_mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 67438
+  timestamp: 1765819100043
+- conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.11.0-5_h2a3cdd5_mkl.conda
+  build_number: 5
+  sha256: 49dc59d8e58360920314b8d276dd80da7866a1484a9abae4ee2760bc68f3e68d
+  md5: b3fa8e8b55310ba8ef0060103afb02b5
+  depends:
+  - libblas 3.11.0 5_hf2e6a31_mkl
+  constrains:
+  - liblapack  3.11.0   5*_mkl
+  - liblapacke 3.11.0   5*_mkl
+  - blas 2.305   mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 68079
+  timestamp: 1765819124349
 - conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.18.0-h43ecb02_0.conda
   sha256: 86258e30845571ea13855e8a0605275905781476f3edf8ae5df90a06fcada93a
   md5: 2688214a9bee5d5650cd4f5f6af5c8f2
@@ -1436,6 +1490,47 @@ packages:
   purls: []
   size: 44978
   timestamp: 1743435053850
+- conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.12.2-default_h4379cf1_1000.conda
+  sha256: 8cdf11333a81085468d9aa536ebb155abd74adc293576f6013fc0c85a7a90da3
+  md5: 3b576f6860f838f950c570f4433b086e
+  depends:
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 2411241
+  timestamp: 1765104337762
+- conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.18-hc1393d2_2.conda
+  sha256: 0dcdb1a5f01863ac4e8ba006a8b0dc1a02d2221ec3319b5915a1863254d7efa7
+  md5: 64571d1dd6cdcfa25d0664a5950fdaa2
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: LGPL-2.1-only
+  purls: []
+  size: 696926
+  timestamp: 1754909290005
+- conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.11.0-5_hf9ab0e9_mkl.conda
+  build_number: 5
+  sha256: a2d33f5cc2b8a9042f2af6981c6733ab1a661463823eaa56595a9c58c0ab77e1
+  md5: e62c42a4196dee97d20400612afcb2b1
+  depends:
+  - libblas 3.11.0 5_hf2e6a31_mkl
+  constrains:
+  - libcblas   3.11.0   5*_mkl
+  - blas 2.305   mkl
+  - liblapacke 3.11.0   5*_mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 80225
+  timestamp: 1765819148014
 - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.2-hfd05255_0.conda
   sha256: f25bf293f550c8ed2e0c7145eb404324611cfccff37660869d97abf526eb957c
   md5: ba0bfd4c3cf73f299ffe46ff0eaeb8e3
@@ -1498,6 +1593,54 @@ packages:
   purls: []
   size: 297087
   timestamp: 1753948490874
+- conda: https://conda.anaconda.org/conda-forge/win-64/libwinpthread-12.0.0.r4.gg4f2fc60ca-h57928b3_10.conda
+  sha256: 0fccf2d17026255b6e10ace1f191d0a2a18f2d65088fd02430be17c701f8ffe0
+  md5: 8a86073cf3b343b87d03f41790d8b4e5
+  depends:
+  - ucrt
+  constrains:
+  - pthreads-win32 <0.0a0
+  - msys2-conda-epoch <0.0a0
+  license: MIT AND BSD-3-Clause-Clear
+  purls: []
+  size: 36621
+  timestamp: 1759768399557
+- conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.15.2-h5d26750_0.conda
+  sha256: f905eb7046987c336122121759e7f09144729f6898f48cd06df2a945b86998d8
+  md5: 1007e1bfe181a2aee214779ee7f13d30
+  depends:
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.2,<6.0a0
+  - libxml2-16 2.15.2 h692994f_0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - icu <0.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 43681
+  timestamp: 1772704748950
+- conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-16-2.15.2-h692994f_0.conda
+  sha256: b8c71b3b609c7cfe17f3f2a47c75394d7b30acfb8b34ad7a049ea8757b4d33df
+  md5: e365238134188e42ed36ee996159d482
+  depends:
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.2,<6.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - libxml2 2.15.2
+  - icu <0.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 520078
+  timestamp: 1772704728534
 - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
   sha256: ba945c6493449bed0e6e29883c4943817f7c79cbff52b83360f7b341277c6402
   md5: 41fbfac52c601159df6c01f875de31b9
@@ -1512,6 +1655,21 @@ packages:
   purls: []
   size: 55476
   timestamp: 1727963768015
+- conda: https://conda.anaconda.org/conda-forge/win-64/llvm-openmp-22.1.0-h4fa8253_0.conda
+  sha256: bb55a3736380759d338f87aac68df4fd7d845ae090b94400525f5d21a55eea31
+  md5: e5505e0b7d6ef5c19d5c0c1884a2f494
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - openmp 22.1.0|22.1.0.*
+  - intel-openmp <0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  purls: []
+  size: 347404
+  timestamp: 1772025050288
 - pypi: https://files.pythonhosted.org/packages/70/ae/44c4a6a4cbb496d93c6257954260fe3a6e91b7bed2240e5dad2a717f5111/markdown-3.9-py3-none-any.whl
   name: markdown
   version: '3.9'
@@ -1757,6 +1915,20 @@ packages:
   - griffe>=1.13
   - typing-extensions>=4.0 ; python_full_version < '3.11'
   requires_python: '>=3.9'
+- conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2025.3.0-hac47afa_455.conda
+  sha256: b2b4c84b95210760e4d12319416c60ab66e03674ccdcbd14aeb59f82ebb1318d
+  md5: fd05d1e894497b012d05a804232254ed
+  depends:
+  - llvm-openmp >=21.1.8
+  - tbb >=2022.3.0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: LicenseRef-IntelSimplifiedSoftwareOct2022
+  license_family: Proprietary
+  purls: []
+  size: 100224829
+  timestamp: 1767634557029
 - pypi: https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl
   name: more-itertools
   version: 10.8.0
@@ -1910,11 +2082,26 @@ packages:
   - pytest-jupyter ; extra == 'test'
   - pytest-tornasync ; extra == 'test'
   requires_python: '>=3.7'
-- pypi: https://files.pythonhosted.org/packages/1b/b5/263ebbbbcede85028f30047eab3d58028d7ebe389d6493fc95ae66c636ab/numpy-2.3.3-cp313-cp313-win_amd64.whl
-  name: numpy
-  version: 2.3.3
-  sha256: f0dadeb302887f07431910f67a14d57209ed91130be0adea2f9793f1a4f817cf
-  requires_python: '>=3.11'
+- conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.4.2-py313hce7ae62_1.conda
+  sha256: a926b0f781c44fdd10e11ec7e7a86ac588ec40b339ac2b4a8459def6d99b613b
+  md5: 7db4fcf0a8a985d3f15270ddc7ac0aac
+  depends:
+  - python
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - liblapack >=3.9.0,<4.0a0
+  - python_abi 3.13.* *_cp313
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/numpy?source=hash-mapping
+  size: 7251046
+  timestamp: 1770098409520
 - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.5.2-h725018a_0.conda
   sha256: 2413f3b4606018aea23acfa2af3c4c46af786739ab4020422e9f0c2aec75321b
   md5: 150d3920b420a27c0848acca158f94dc
@@ -2066,10 +2253,10 @@ packages:
   - pkg:pypi/pathspec?source=compressed-mapping
   size: 53739
   timestamp: 1769677743677
-- pypi: https://files.pythonhosted.org/packages/23/85/397c73524e0cd212067e0c969aa245b01d50183439550d24d9f55781b776/pillow-11.3.0-cp313-cp313-win_amd64.whl
+- pypi: https://files.pythonhosted.org/packages/3f/eb/b0834ad8b583d7d9d42b80becff092082a1c3c156bb582590fcc973f1c7c/pillow-12.1.1-cp313-cp313-win_amd64.whl
   name: pillow
-  version: 11.3.0
-  sha256: 0bce5c4fd0921f99d2e858dc4d4d64193407e1b99478bc5cacecba2311abde51
+  version: 12.1.1
+  sha256: 344cf1e3dab3be4b1fa08e449323d98a2a3f819ad20f4b22e77a0ede31f0faa1
   requires_dist:
   - furo ; extra == 'docs'
   - olefile ; extra == 'docs'
@@ -2080,6 +2267,9 @@ packages:
   - sphinxext-opengraph ; extra == 'docs'
   - olefile ; extra == 'fpx'
   - olefile ; extra == 'mic'
+  - arro3-compute ; extra == 'test-arrow'
+  - arro3-core ; extra == 'test-arrow'
+  - nanoarrow ; extra == 'test-arrow'
   - pyarrow ; extra == 'test-arrow'
   - check-manifest ; extra == 'tests'
   - coverage>=7.4.2 ; extra == 'tests'
@@ -2087,15 +2277,14 @@ packages:
   - markdown2 ; extra == 'tests'
   - olefile ; extra == 'tests'
   - packaging ; extra == 'tests'
-  - pyroma ; extra == 'tests'
+  - pyroma>=5 ; extra == 'tests'
   - pytest ; extra == 'tests'
   - pytest-cov ; extra == 'tests'
   - pytest-timeout ; extra == 'tests'
   - pytest-xdist ; extra == 'tests'
   - trove-classifiers>=2024.10.12 ; extra == 'tests'
-  - typing-extensions ; python_full_version < '3.10' and extra == 'typing'
   - defusedxml ; extra == 'xmp'
-  requires_python: '>=3.9'
+  requires_python: '>=3.10'
 - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.0.1-pyh145f28c_0.conda
   sha256: 5f66ea31d62188c266c5a8752119b0cc90a5bf05963f665cf48a33e0ec58d39c
   md5: 09a970fbf75e8ed1aa633827ded6aa4f
@@ -2433,13 +2622,13 @@ packages:
   - pkg:pypi/scikit-build-core?source=hash-mapping
   size: 213181
   timestamp: 1755919500167
-- pypi: https://files.pythonhosted.org/packages/21/12/c0efd2941f01940119b5305c375ae5c0fcb7ec193f806bd8f158b73a1782/scipy-1.16.1-cp313-cp313-win_amd64.whl
+- pypi: https://files.pythonhosted.org/packages/35/e5/d6d0e51fc888f692a35134336866341c08655d92614f492c6860dc45bb2c/scipy-1.17.1-cp313-cp313-win_amd64.whl
   name: scipy
-  version: 1.16.1
-  sha256: 81929ed0fa7a5713fcdd8b2e6f73697d3b4c4816d090dd34ff937c20fa90e8ab
+  version: 1.17.1
+  sha256: 37425bc9175607b0268f493d79a292c39f9d001a357bebb6b88fdfaff13f6448
   requires_dist:
-  - numpy>=1.25.2,<2.6
-  - pytest ; extra == 'test'
+  - numpy>=1.26.4,<2.7
+  - pytest>=8.0.0 ; extra == 'test'
   - pytest-cov ; extra == 'test'
   - pytest-timeout ; extra == 'test'
   - pytest-xdist ; extra == 'test'
@@ -2467,15 +2656,15 @@ packages:
   - jupyterlite-sphinx>=0.19.1 ; extra == 'doc'
   - jupyterlite-pyodide-kernel ; extra == 'doc'
   - linkify-it-py ; extra == 'doc'
+  - tabulate ; extra == 'doc'
+  - click<8.3.0 ; extra == 'dev'
+  - spin ; extra == 'dev'
   - mypy==1.10.0 ; extra == 'dev'
   - typing-extensions ; extra == 'dev'
   - types-psutil ; extra == 'dev'
   - pycodestyle ; extra == 'dev'
-  - ruff>=0.0.292 ; extra == 'dev'
+  - ruff>=0.12.0 ; extra == 'dev'
   - cython-lint>=0.12.2 ; extra == 'dev'
-  - rich-click ; extra == 'dev'
-  - doit>=0.36.0 ; extra == 'dev'
-  - pydevtool ; extra == 'dev'
   requires_python: '>=3.11'
 - pypi: https://files.pythonhosted.org/packages/83/11/00d3c3dfc25ad54e731d91449895a79e4bf2384dc3ac01809010ba88f6d5/seaborn-0.13.2-py3-none-any.whl
   name: seaborn
@@ -2600,6 +2789,19 @@ packages:
   - pygments ; extra == 'tests'
   - littleutils ; extra == 'tests'
   - cython ; extra == 'tests'
+- conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2022.3.0-h3155e25_2.conda
+  sha256: abd9a489f059fba85c8ffa1abdaa4d515d6de6a3325238b8e81203b913cf65a9
+  md5: 0f9817ffbe25f9e69ceba5ea70c52606
+  depends:
+  - libhwloc >=2.12.2,<2.12.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 155869
+  timestamp: 1767886839029
 - pypi: https://files.pythonhosted.org/packages/6a/9e/2064975477fdc887e47ad42157e214526dcad8f317a948dee17e1659a62f/terminado-0.18.1-py3-none-any.whl
   name: terminado
   version: 0.18.1
@@ -2868,6 +3070,11 @@ packages:
   - pytest>=6.0.0 ; extra == 'test'
   - setuptools>=65 ; extra == 'test'
   requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/3f/0e/fa3b193432cfc60c93b42f3be03365f5f909d2b3ea410295cf36df739e31/widgetsnbextension-4.0.15-py3-none-any.whl
+  name: widgetsnbextension
+  version: 4.0.15
+  sha256: 8156704e4346a571d9ce73b84bee86a29906c9abfd7223b7228a28899ccf3366
+  requires_python: '>=3.7'
 - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
   sha256: b4533f7d9efc976511a73ef7d4a2473406d7f4c750884be8e8620b0ce70f4dae
   md5: 30cd29cb87d819caead4d55184c1d115

--- a/pixi.lock
+++ b/pixi.lock
@@ -620,8 +620,8 @@ packages:
   requires_python: '>=3.9'
 - pypi: ./
   name: gropt
-  version: 2.0.0rc3.dev16
-  sha256: 12cd27c12a7f063bdb81a8f58f281cd3e067ed12eead109a7e64aad6d5736525
+  version: 2.0.0rc3.dev13+g907a738b2.d20260302
+  sha256: 41d4e5e431f3c0136b98e0b66c8e84f523358be20676a2bdab45e6bf80e0dd2b
   requires_dist:
   - numpy
   - pyqt6 ; extra == 'gui'

--- a/pixi.lock
+++ b/pixi.lock
@@ -620,8 +620,8 @@ packages:
   requires_python: '>=3.9'
 - pypi: ./
   name: gropt
-  version: 2.0.0rc3.dev13+g907a738b2.d20260302
-  sha256: 41d4e5e431f3c0136b98e0b66c8e84f523358be20676a2bdab45e6bf80e0dd2b
+  version: 2.0.0rc9.dev2
+  sha256: 4cee9be4ef9e59108f7ed06e91f9597036c7f8145588354c57d04e4c7fd9ad10
   requires_dist:
   - numpy
   - pyqt6 ; extra == 'gui'

--- a/pixi.lock
+++ b/pixi.lock
@@ -620,8 +620,8 @@ packages:
   requires_python: '>=3.9'
 - pypi: ./
   name: gropt
-  version: 2.0.0rc3.dev6+g5b39e98ec.d20260227
-  sha256: 763c010a44ba6704d3343a6e55c62975f49edf9f797be8fb1272505a11291388
+  version: 2.0.0rc3.dev16
+  sha256: 12cd27c12a7f063bdb81a8f58f281cd3e067ed12eead109a7e64aad6d5736525
   requires_dist:
   - numpy
   - pyqt6 ; extra == 'gui'

--- a/pixi.lock
+++ b/pixi.lock
@@ -62,8 +62,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.13.7-hdf00ec1_100_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/scikit-build-core-0.11.6-pyh7e86bf3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.0-pyh332efcf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-scm-9.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h2c6b04d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
@@ -202,6 +200,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/21/12/c0efd2941f01940119b5305c375ae5c0fcb7ec193f806bd8f158b73a1782/scipy-1.16.1-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/83/11/00d3c3dfc25ad54e731d91449895a79e4bf2384dc3ac01809010ba88f6d5/seaborn-0.13.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/40/b0/4562db6223154aa4e22f939003cb92514c79f3d4dccca3444253fd17f902/Send2Trash-1.8.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/c6/76dc613121b793286a3f91621d7b75a2b493e0390ddca50f11993eadf192/setuptools-82.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/14/a0/bb38d3b76b8cae341dad93a2dd83ab7462e6dbcdd84d43f54ee60a8dc167/soupsieve-2.8-py3-none-any.whl
@@ -620,8 +619,8 @@ packages:
   requires_python: '>=3.9'
 - pypi: ./
   name: gropt
-  version: 2.0.0rc9.dev2
-  sha256: 4cee9be4ef9e59108f7ed06e91f9597036c7f8145588354c57d04e4c7fd9ad10
+  version: 2.0.0rc9
+  sha256: daf53abcf42f25d8bd20748b5a568c717197b72cc5bb0affc1047a66c6076ff6
   requires_dist:
   - numpy
   - pyqt6 ; extra == 'gui'
@@ -2516,33 +2515,63 @@ packages:
   - pyobjc-framework-cocoa ; sys_platform == 'darwin' and extra == 'objc'
   - pywin32 ; sys_platform == 'win32' and extra == 'win32'
   requires_python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*'
-- conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.0-pyh332efcf_0.conda
-  sha256: fd7201e38e38bf7f25818d624ca8da97b8998957ca9ae3fb7fdc9c17e6b25fcd
-  md5: 1d00d46c634177fc8ede8b99d6089239
-  depends:
-  - python >=3.10
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/setuptools?source=compressed-mapping
-  size: 637506
-  timestamp: 1770634745653
-- conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-scm-9.2.2-pyhd8ed1ab_0.conda
-  sha256: 2161ac35fc22770b248bab0be2cc3b5bd765f528a9e60e7f3be784fd8d0d605a
-  md5: e2e4d7094d0580ccd62e2a41947444f3
-  depends:
-  - importlib-metadata
-  - packaging >=20.0
-  - python >=3.10
-  - setuptools >=45
-  - tomli >=1.0.0
-  - typing-extensions
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/setuptools-scm?source=hash-mapping
-  size: 52539
-  timestamp: 1760965125925
+- pypi: https://files.pythonhosted.org/packages/e1/c6/76dc613121b793286a3f91621d7b75a2b493e0390ddca50f11993eadf192/setuptools-82.0.0-py3-none-any.whl
+  name: setuptools
+  version: 82.0.0
+  sha256: 70b18734b607bd1da571d097d236cfcfacaf01de45717d59e6e04b96877532e0
+  requires_dist:
+  - pytest>=6,!=8.1.* ; extra == 'test'
+  - virtualenv>=13.0.0 ; extra == 'test'
+  - wheel>=0.44.0 ; extra == 'test'
+  - pip>=19.1 ; extra == 'test'
+  - packaging>=24.2 ; extra == 'test'
+  - jaraco-envs>=2.2 ; extra == 'test'
+  - pytest-xdist>=3 ; extra == 'test'
+  - jaraco-path>=3.7.2 ; extra == 'test'
+  - build[virtualenv]>=1.0.3 ; extra == 'test'
+  - filelock>=3.4.0 ; extra == 'test'
+  - ini2toml[lite]>=0.14 ; extra == 'test'
+  - tomli-w>=1.0.0 ; extra == 'test'
+  - pytest-timeout ; extra == 'test'
+  - pytest-perf ; sys_platform != 'cygwin' and extra == 'test'
+  - jaraco-develop>=7.21 ; python_full_version >= '3.9' and sys_platform != 'cygwin' and extra == 'test'
+  - pytest-home>=0.5 ; extra == 'test'
+  - pytest-subprocess ; extra == 'test'
+  - pyproject-hooks!=1.1 ; extra == 'test'
+  - jaraco-test>=5.5 ; extra == 'test'
+  - sphinx>=3.5 ; extra == 'doc'
+  - jaraco-packaging>=9.3 ; extra == 'doc'
+  - rst-linker>=1.9 ; extra == 'doc'
+  - furo ; extra == 'doc'
+  - sphinx-lint ; extra == 'doc'
+  - jaraco-tidelift>=1.4 ; extra == 'doc'
+  - pygments-github-lexers==0.0.5 ; extra == 'doc'
+  - sphinx-favicon ; extra == 'doc'
+  - sphinx-inline-tabs ; extra == 'doc'
+  - sphinx-reredirects ; extra == 'doc'
+  - sphinxcontrib-towncrier ; extra == 'doc'
+  - sphinx-notfound-page>=1,<2 ; extra == 'doc'
+  - pyproject-hooks!=1.1 ; extra == 'doc'
+  - towncrier<24.7 ; extra == 'doc'
+  - packaging>=24.2 ; extra == 'core'
+  - more-itertools>=8.8 ; extra == 'core'
+  - jaraco-text>=3.7 ; extra == 'core'
+  - importlib-metadata>=6 ; python_full_version < '3.10' and extra == 'core'
+  - tomli>=2.0.1 ; python_full_version < '3.11' and extra == 'core'
+  - wheel>=0.43.0 ; extra == 'core'
+  - platformdirs>=4.2.2 ; extra == 'core'
+  - jaraco-functools>=4 ; extra == 'core'
+  - more-itertools ; extra == 'core'
+  - pytest-checkdocs>=2.4 ; extra == 'check'
+  - pytest-ruff>=0.2.1 ; sys_platform != 'cygwin' and extra == 'check'
+  - ruff>=0.13.0 ; sys_platform != 'cygwin' and extra == 'check'
+  - pytest-cov ; extra == 'cover'
+  - pytest-enabler>=2.2 ; extra == 'enabler'
+  - pytest-mypy ; extra == 'type'
+  - mypy==1.18.* ; extra == 'type'
+  - importlib-metadata>=7.0.2 ; python_full_version < '3.10' and extra == 'type'
+  - jaraco-develop>=7.21 ; sys_platform != 'cygwin' and extra == 'type'
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
   name: six
   version: 1.17.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ environment-pass = ["SETUPTOOLS_SCM_PRETEND_VERSION"]
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]
-environment = {MACOSX_DEPLOYMENT_TARGET = "10.13"}
+environment = { MACOSX_DEPLOYMENT_TARGET = "10.13" }
 
 [tool.pixi.workspace]
 channels = ["conda-forge"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,9 @@ docs = [
 requires = ["scikit-build-core>=0.10", "nanobind>=2.0"]
 build-backend = "scikit_build_core.build"
 
+[tool.scikit-build]
+build-dir = ".scikit-build"
+
 [tool.cibuildwheel]
 build = "cp310-* cp311-* cp312-* cp313-* cp314-*"
 skip = "*-musllinux_* *-manylinux_i686 *-win32"
@@ -47,9 +50,8 @@ dev = { features = ["dev", "docs"], solve-group = "default" }
 
 [tool.pixi.tasks]
 clean = "python clean.py"
-rebuild = { cmd = "python -m pip install --no-build-isolation -v -e .", depends-on = [
-    "clean",
-] }
-rebuild-test = { cmd = "python -m pip install --no-build-isolation -v -e . -C cmake.define.GROPT_EIGEN_ASSERTIONS=ON", depends-on = [
-    "clean",
-] }
+clean-full = "python clean.py --full"
+touch-wrapper = "python -c \"from pathlib import Path; Path('gropt/gropt_wrapper/gropt_wrapper.cpp').touch()\""
+rebuild = { cmd = "python -m pip install --no-build-isolation -v -e .", depends-on = ["clean", "touch-wrapper"] }
+rebuild-full = { cmd = "python -m pip install --no-build-isolation -v -e .", depends-on = ["clean-full", "touch-wrapper"] }
+rebuild-test = { cmd = "python -m pip install --no-build-isolation -v -e . -C cmake.define.GROPT_EIGEN_ASSERTIONS=ON", depends-on = ["clean-full", "touch-wrapper"] }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ dependencies = ["numpy"]
 
 [project.optional-dependencies]
 gui = ["pyqt6", "matplotlib"]
-dev = ["jupyterlab", "wheel", "scipy", "twine", "seaborn"]
+dev = ["jupyterlab", "wheel", "scipy", "twine", "seaborn", "ipywidgets"]
 docs = [
     "mkdocs",
     "mkdocs-material",
@@ -35,12 +35,14 @@ environment = { MACOSX_DEPLOYMENT_TARGET = "10.13" }
 channels = ["conda-forge"]
 platforms = ["win-64"]
 
-[tool.pixi.pypi-dependencies]
-gropt = { path = ".", editable = true }
+# This messes up the rebuild commands, dont let pixi handle gropt at all, we will do it manually with pip install -e . in the tasks section.
+# [tool.pixi.pypi-dependencies]
+# gropt = { path = ".", editable = true }
 
 [tool.pixi.feature.dev.dependencies]
 cmake = ">=3.17"
 nanobind = ">=2.0"
+numpy = "*"
 scikit-build-core = ">=0.10"
 pip = "*"
 
@@ -52,6 +54,15 @@ dev = { features = ["dev", "docs"], solve-group = "default" }
 clean = "python clean.py"
 clean-full = "python clean.py --full"
 touch-wrapper = "python -c \"from pathlib import Path; Path('gropt/gropt_wrapper/gropt_wrapper.cpp').touch()\""
-rebuild = { cmd = "python -m pip install --no-build-isolation -v -e .", depends-on = ["clean", "touch-wrapper"] }
-rebuild-full = { cmd = "python -m pip install --no-build-isolation -v -e .", depends-on = ["clean-full", "touch-wrapper"] }
-rebuild-test = { cmd = "python -m pip install --no-build-isolation -v -e . -C cmake.define.GROPT_EIGEN_ASSERTIONS=ON", depends-on = ["clean-full", "touch-wrapper"] }
+rebuild = { cmd = "python -m pip install --no-build-isolation -v -e .", depends-on = [
+    "clean",
+    "touch-wrapper",
+] }
+rebuild-full = { cmd = "python -m pip install --no-build-isolation -v -e .", depends-on = [
+    "clean-full",
+    "touch-wrapper",
+] }
+rebuild-test = { cmd = "python -m pip install --no-build-isolation -v -e . -C cmake.define.GROPT_EIGEN_ASSERTIONS=ON", depends-on = [
+    "clean-full",
+    "touch-wrapper",
+] }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gropt"
-dynamic = ["version"]
+version = "2.0.0rc9"
 requires-python = ">=3.10"
 dependencies = ["numpy"]
 
@@ -16,20 +16,13 @@ docs = [
 ]
 
 [build-system]
-requires = ["scikit-build-core>=0.10", "nanobind>=2.0", "setuptools-scm>=8"]
+requires = ["scikit-build-core>=0.10", "nanobind>=2.0"]
 build-backend = "scikit_build_core.build"
-
-[tool.scikit-build.metadata.version]
-provider = "scikit_build_core.metadata.setuptools_scm"
-
-[tool.setuptools_scm]
-local_scheme = "no-local-version"
 
 [tool.cibuildwheel]
 build = "cp310-* cp311-* cp312-* cp313-* cp314-*"
 skip = "*-musllinux_* *-manylinux_i686 *-win32"
 test-command = "python -c \"import gropt; gropt.demo()\""
-environment-pass = ["SETUPTOOLS_SCM_PRETEND_VERSION"]
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]
@@ -46,7 +39,6 @@ gropt = { path = ".", editable = true }
 cmake = ">=3.17"
 nanobind = ">=2.0"
 scikit-build-core = ">=0.10"
-setuptools-scm = ">=8"
 pip = "*"
 
 [tool.pixi.environments]


### PR DESCRIPTION
## Summary
- Improved OSQP solver with adaptive reweighting and extra iteration support
- Added matrix equilibration enhancements (Ruiz equilibration, row/column norm estimation)
- Added concomitant gradient constraint operator
- Replaced all legacy `double*` raw pointer interfaces with Eigen types (setvec_X0, add_SAFE, SAFEParams, Op_SAFE constructor, get_SAFE utils)
- Removed unused `get_result_X` from both solvers — results returned via `SolveResult` object
- Compiled solver sources as static lib separate from nanobind wrapper
- Replaced setuptools-scm with static version + CI version guard
- Added Eigen assertion tests

## Test plan
- [ ] Verify `pixi run -e dev build` compiles cleanly
- [ ] Run existing notebooks (diffusion, SAFE) to confirm no regressions
- [ ] Verify Python bindings work with numpy arrays for all modified methods