### PR TITLE
Fix diff_init_deadtime off-by-one and concomitant prox scaling

### DIFF
--- a/gropt/diff.py
+++ b/gropt/diff.py
@@ -1,0 +1,9 @@
+import gropt
+
+
+def diff_solve(gparams, extra_iters=2000, ils_max_iter=30):
+    solver = gropt.SolverGroptSDMM()
+    solver.set_general_params(max_feval=200000, max_iter=20000, gamma_x=1.5, extra_iters=extra_iters)
+    solver.set_ils_params(ils_max_iter=ils_max_iter, ils_tol=1e-12, ils_sigma=0.0001, ils_tik_lam=0.0001)
+    result = solver.solve(gparams)
+    return result

--- a/gropt/gropt_wrapper.pyi
+++ b/gropt/gropt_wrapper.pyi
@@ -6,7 +6,7 @@ import numpy
 from numpy.typing import NDArray
 
 
-__build_date__: str = 'Mar 11 2026 21:46:53'
+__build_date__: str = 'Mar 11 2026 22:45:32'
 
 def set_log_level(level: int) -> None:
     """
@@ -124,6 +124,25 @@ class GroptParams:
     def diff_init(self, dt: float = 0.0004, TE: float = 0.08, T_90: float = 0.003, T_180: float = 0.005, T_readout: float = 0.016) -> None:
         """
         Initialize diffusion sequence parameters.
+
+        Parameters
+        ----------
+        dt : float, optional
+            Raster time in seconds.
+        TE : float, optional
+            Echo time in seconds.
+        T_90 : float, optional
+            Duration of excitation RF pulse in seconds (time from excitation,
+            so half of full RF pulse duration).
+        T_180 : float, optional
+            Duration of refocusing RF pulse in seconds.
+        T_readout : float, optional
+            Time to TE of the readout in seconds.
+        """
+
+    def diff_init_deadtime(self, dt: float = 0.0004, TE: float = 0.08, T_90: float = 0.003, T_180: float = 0.005, T_readout: float = 0.016) -> None:
+        """
+        Initialize diffusion sequence parameters, but with forced deadtime to make "convnetional" waveforms.
 
         Parameters
         ----------

--- a/gropt/gropt_wrapper.pyi
+++ b/gropt/gropt_wrapper.pyi
@@ -6,7 +6,7 @@ import numpy
 from numpy.typing import NDArray
 
 
-__build_date__: str = 'Mar 11 2026 22:45:32'
+__build_date__: str = 'Mar 11 2026 23:37:02'
 
 def set_log_level(level: int) -> None:
     """
@@ -71,6 +71,12 @@ class SolveResult:
 
     @dt.setter
     def dt(self, arg: float, /) -> None: ...
+
+    @property
+    def bvalue(self) -> float: ...
+
+    @bvalue.setter
+    def bvalue(self, arg: float, /) -> None: ...
 
     def __repr__(self) -> str: ...
 

--- a/gropt/gropt_wrapper/gropt_wrapper.cpp
+++ b/gropt/gropt_wrapper/gropt_wrapper.cpp
@@ -72,6 +72,7 @@ n_feval : int
         .def_rw("n_iter", &Gropt::SolveResult::n_iter)
         .def_rw("n_feval", &Gropt::SolveResult::n_feval)
         .def_rw("dt", &Gropt::SolveResult::dt)
+        .def_rw("bvalue", &Gropt::SolveResult::bvalue)
         .def("__repr__", [](const Gropt::SolveResult &r) {
             return "SolveResult(converged=" + std::string(r.converged ? "True" : "False") +
                    ", n_iter=" + std::to_string(r.n_iter) +

--- a/gropt/plot.py
+++ b/gropt/plot.py
@@ -1,0 +1,157 @@
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+def get_moments(g, dt, inv_vec=None, scale_to_one=True):
+    if g.squeeze().ndim == 2:
+        g = g[0]  # TODO: 3-axis case, right now just assumes 1 axis
+
+    Nm = 5
+    tt = np.arange(g.size) * dt
+    _m = np.zeros((Nm, g.size))
+
+    for mm in range(Nm):
+        _m[mm] = tt**mm
+
+    if inv_vec is not None:
+        mm = dt * _m * (g * inv_vec)[np.newaxis, :]
+    else:
+        mm = dt * _m * g[np.newaxis, :]
+
+    moments = [np.cumsum(x) for x in mm]
+
+    if scale_to_one:
+        moments = [x / np.abs(x).max() for x in moments]
+
+    return moments
+
+
+def get_concomitant(g, dt, inv_vec):
+    pos = np.sum(dt * g[inv_vec > 0] ** 2.0)
+    neg = np.sum(dt * g[inv_vec < 0] ** 2.0)
+
+    ratio = pos / neg
+    if ratio < 1:
+        ratio = 1 / ratio
+
+    return ratio
+
+
+def get_bval(g, dt, inv_vec=None, TE=0):
+    if g.squeeze().ndim == 2:
+        g = g[0]  # TODO: 3-axis case, right now just assumes 1 axis
+
+    if inv_vec is None:
+        inv_vec = np.ones(g.size)
+        tINV = int(np.floor(TE / dt / 2.0))
+        inv_vec[tINV:] = -1
+
+    GAMMA = 42.58e3
+
+    Gt = 0
+    bval = 0
+    for i in range(g.size):
+        Gt += inv_vec[i] * g[i] * dt
+        bval += Gt * Gt * dt
+
+    bval *= (GAMMA * 2 * np.pi) ** 2
+
+    return bval
+
+
+def plot_diff(*args, mode='diff', **kwargs):
+
+    plot_waves(*args, mode=mode, **kwargs)
+
+
+def plot_waves(
+    g,
+    dt,
+    inv_vec=None,
+    TE=0,
+    gmax=0,
+    smax=0,
+    safe_params=None,
+    MMT=4,
+    stim=None,
+    stim_vec=None,
+    stim_lim=0,
+    mode='regular',
+):
+
+    if inv_vec is None:
+        inv_vec = np.ones(g.size)
+        tINV = int(np.floor(TE / dt / 2.0))
+        inv_vec[tINV:] = -1
+
+    tt_ms = np.arange(g.size) * dt * 1e3
+
+    N_rows = 2
+    N_cols = 2
+    f, axarr = plt.subplots(N_rows, N_cols, squeeze=False, figsize=(10, N_rows * 3.0), layout='constrained')
+
+    i_row = 0
+    i_col = 0
+
+    if mode == 'diff':
+        label = ''
+
+        if TE > 0:
+            label += f'TE: {1000 * TE} ms  ---  '
+
+        bval = get_bval(g, dt, inv_vec)
+        label += f'b-value: {bval:.0f} $mm^2/s$  ---  '
+
+        c_ratio = get_concomitant(g, dt, inv_vec)
+        label += f'concomitant ratio: {c_ratio:.1f}'
+
+        f.suptitle(label)
+
+    axarr[i_row, i_col].axhline(linestyle='--', color='0.7')
+    if gmax > 0:
+        axarr[i_row, i_col].axhline(1000 * gmax, linestyle=':', color='r', alpha=0.5)
+        axarr[i_row, i_col].axhline(-1000 * gmax, linestyle=':', color='r', alpha=0.5)
+    axarr[i_row, i_col].plot(tt_ms, g * 1000)
+    axarr[i_row, i_col].set_title('Gradient')
+    axarr[i_row, i_col].set_xlabel('t [ms]')
+
+    i_row = 0
+    i_col = 1
+
+    axarr[i_row, i_col].axhline(linestyle='--', color='0.7')
+    if smax > 0:
+        axarr[i_row, i_col].axhline(smax, linestyle=':', color='r', alpha=0.5)
+        axarr[i_row, i_col].axhline(-smax, linestyle=':', color='r', alpha=0.5)
+    axarr[i_row, i_col].plot(tt_ms[:-1], np.diff(g) / dt)
+    axarr[i_row, i_col].set_title('Slew')
+    axarr[i_row, i_col].set_xlabel('t [ms]')
+
+    i_row = 1
+    i_col = 0
+
+    mm = get_moments(g, dt, inv_vec)
+
+    axarr[i_row, i_col].axhline(linestyle='--', color='0.7')
+    for im in range(5):
+        axarr[i_row, i_col].plot(tt_ms, mm[im], label=f'{im}')
+    axarr[i_row, i_col].legend(loc='upper left')
+    axarr[i_row, i_col].set_title('Moments')
+    axarr[i_row, i_col].set_xlabel('t [ms]')
+
+    i_row = 1
+    i_col = 1
+
+    if stim is not None:
+        axarr[i_row, i_col].plot(tt_ms, stim)
+
+        if stim_vec is not None:
+            axarr[i_row, i_col].plot(tt_ms, stim_vec, linestyle=':', color='r', alpha=0.5)
+        if stim_lim > 0:
+            axarr[i_row, i_col].axhline(stim_lim, linestyle=':', color='r', alpha=0.5)
+
+        axarr[i_row, i_col].axhline(linestyle='--', color='0.7')
+
+    axarr[i_row, i_col].set_title('SAFE PNS')
+    axarr[i_row, i_col].set_xlabel('t [ms]')
+
+    plt.show()

--- a/gropt/src/gropt_params.cpp
+++ b/gropt/src/gropt_params.cpp
@@ -156,7 +156,7 @@ void GroptParams::diff_init_deadtime(double _dt, double _TE, double _T_90, doubl
     ind_180_end = ceil((TE / 2.0 + T_180 / 2.0) / dt);
 
     int live_time = N - ind_180_end;
-    ind_180_start = ind_90_end + live_time;
+    ind_180_start = ind_90_end + live_time - 1;
 
     pdata.set_vals.setOnes(N);
     pdata.set_vals.array() *= NAN;

--- a/gropt/src/gropt_params.cpp
+++ b/gropt/src/gropt_params.cpp
@@ -129,6 +129,7 @@ void GroptParams::diff_init(double _dt, double _TE, double _T_90, double _T_180,
             pdata.X0(i) = 1e-2; // Initial value for non-fixed points
         }
     }
+    pdata.X0.array() *= pdata.inv_vec.array();
 
     vec_init_status = N;
 }
@@ -184,6 +185,8 @@ void GroptParams::diff_init_deadtime(double _dt, double _TE, double _T_90, doubl
             pdata.X0(i) = 1e-2; // Initial value for non-fixed points
         }
     }
+
+    pdata.X0.array() *= pdata.inv_vec.array();
 
     vec_init_status = N;
 }

--- a/gropt/src/gropt_params.hpp
+++ b/gropt/src/gropt_params.hpp
@@ -26,6 +26,7 @@ struct SolveResult {
     int n_iter = 0;
     int n_feval = 0;
     double dt = 0.0;
+    double bvalue = 0.0;
 };
 
 class GroptParams {

--- a/gropt/src/op_bvalue.cpp
+++ b/gropt/src/op_bvalue.cpp
@@ -170,6 +170,7 @@ void Op_BValue::check(Eigen::VectorXd &X) {
 double Op_BValue::get_bvalue(Eigen::VectorXd &X) {
     Ax_temp.setZero();
     forward_op(X, Ax_temp);
+    Ax_temp.array() *= spec_norm;
 
     return Ax_temp.squaredNorm();
 }

--- a/gropt/src/op_concomitant.cpp
+++ b/gropt/src/op_concomitant.cpp
@@ -53,16 +53,20 @@ void Op_Concomitant::prox(Eigen::VectorXd &X) {
     }
 
     if (pos > neg) {
-        double scale = 1.0 / sqrt(pos / neg);
+        double scale = sqrt(sqrt(pos / neg));
         for (int i = 0; i < X.size(); i++) {
             if (pdata->inv_vec(i) > 0) {
+                X(i) /= scale;
+            } else {
                 X(i) *= scale;
             }
         }
     } else if (neg > pos) {
-        double scale = 1.0 / sqrt(neg / pos);
+        double scale = sqrt(sqrt(neg / pos));
         for (int i = 0; i < X.size(); i++) {
             if (pdata->inv_vec(i) < 0) {
+                X(i) /= scale;
+            } else {
                 X(i) *= scale;
             }
         }

--- a/gropt/src/solver.cpp
+++ b/gropt/src/solver.cpp
@@ -1,6 +1,7 @@
 #include "spdlog/spdlog.h"
 
 #include "solver.hpp"
+#include "op_bvalue.hpp"
 
 namespace Gropt {
 
@@ -60,6 +61,19 @@ void Solver::final_log(Eigen::VectorXd &X, SolveResult &result) {
 
         if (op->hist_feas.back() == 0) {
             result.converged = false;
+        }
+    }
+
+    // Check if one of the constraints is b-value and if so, report the final b-value
+    for (int i = 0; i < gparams->all_op.size(); i++) {
+        Operator *op = gparams->all_op[i].get();
+        if (op->name == "b-value") {
+            Op_BValue *op_bvalue = dynamic_cast<Op_BValue *>(op);
+            if (op_bvalue != nullptr) {
+                result.bvalue = op_bvalue->get_bvalue(X);
+            } else {
+                spdlog::warn("Operator named 'b-value' is not an Op_BValue instance.");
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Fix off-by-one in `diff_init_deadtime`: `ind_180_start` was one index too high
- Fix concomitant prox scaling: use fourth root and apply inverse scaling to the opposite polarity

## Test plan
- [ ] Verify diffusion waveforms with `diff_init_deadtime` produce symmetric shapes
- [ ] Verify concomitant constraint convergence