### PR TITLE
Add per-location slew rate constraint (v2.0.0rc13)

### DIFF
--- a/gropt/gropt_wrapper.pyi
+++ b/gropt/gropt_wrapper.pyi
@@ -6,7 +6,7 @@ import numpy
 from numpy.typing import NDArray
 
 
-__build_date__: str = 'May  7 2026 13:43:33'
+__build_date__: str = 'May 17 2026 09:36:00'
 
 def set_log_level(level: int) -> None:
     """
@@ -298,6 +298,23 @@ class GroptParams:
             Maximum allowed gradient slew rate [T/m/s].
         rot_variant : bool, optional
             If True, use rotationally invariant formulation.
+        weight_mod : float, optional
+            Weighting factor for this constraint.
+        """
+
+    def add_smax_vec(self, smax_vec: Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')], rot_variant: bool = True, weight_mod: float = 1.0) -> None:
+        """
+        Add a per-location slew rate constraint.
+
+        Parameters
+        ----------
+        smax_vec : np.ndarray
+            Slew-rate limit at each location [T/m/s]. Length (N-1) is broadcast
+            across all axes; length Naxis*(N-1) sets a per-axis limit. Only
+            supported with rot_variant=True.
+        rot_variant : bool, optional
+            Must be True. A vector limit on the slew magnitude across axes is
+            not supported.
         weight_mod : float, optional
             Weighting factor for this constraint.
         """

--- a/gropt/gropt_wrapper/gropt_wrapper.cpp
+++ b/gropt/gropt_wrapper/gropt_wrapper.cpp
@@ -326,6 +326,24 @@ weight_mod : float, optional
     Weighting factor for this constraint.)doc"
         )
 
+        // add_smax_vec
+        .def("add_smax_vec", &Gropt::GroptParams::add_smax_vec,
+            "smax_vec"_a, "rot_variant"_a = true, "weight_mod"_a = 1.0,
+R"doc(Add a per-location slew rate constraint.
+
+Parameters
+----------
+smax_vec : np.ndarray
+    Slew-rate limit at each location [T/m/s]. Length (N-1) is broadcast
+    across all axes; length Naxis*(N-1) sets a per-axis limit. Only
+    supported with rot_variant=True.
+rot_variant : bool, optional
+    Must be True. A vector limit on the slew magnitude across axes is
+    not supported.
+weight_mod : float, optional
+    Weighting factor for this constraint.)doc"
+        )
+
         // add_moment
         .def("add_moment", &Gropt::GroptParams::add_moment,
             "order"_a = 0, "target"_a = 0.0, "tol"_a = 1e-6, "units"_a = "mT*ms/m",

--- a/gropt/src/gropt_params.cpp
+++ b/gropt/src/gropt_params.cpp
@@ -343,6 +343,10 @@ void GroptParams::add_smax(double smax, bool rot_variant, double weight_mod) {
     all_op.push_back(std::make_unique<Op_Slew>(pdata, smax, rot_variant, weight_mod));
 }
 
+void GroptParams::add_smax_vec(const Eigen::VectorXd &smax_vec, bool rot_variant, double weight_mod) {
+    all_op.push_back(std::make_unique<Op_Slew>(pdata, smax_vec, rot_variant, weight_mod));
+}
+
 void GroptParams::add_concomitant(int start_idx, bool rot_variant, double weight_mod) {
     all_op.push_back(std::make_unique<Op_Concomitant>(pdata, start_idx, rot_variant, weight_mod));
 }

--- a/gropt/src/gropt_params.hpp
+++ b/gropt/src/gropt_params.hpp
@@ -73,6 +73,7 @@ class GroptParams {
 
     void add_gmax(double gmax, bool rot_variant, double weight_mod);
     void add_smax(double smax, bool rot_variant, double weight_mod);
+    void add_smax_vec(const Eigen::VectorXd &smax_vec, bool rot_variant, double weight_mod);
     void add_concomitant(int start_idx, bool rot_variant, double weight_mod);
     void add_moment(double order, double target, double tol0, std::string units, int moment_axis, int start_idx0,
                     int stop_idx0, int ref_idx0, double weight_mod);

--- a/gropt/src/op_slew.cpp
+++ b/gropt/src/op_slew.cpp
@@ -11,6 +11,18 @@ Op_Slew::Op_Slew(const ProblemData &_pdata, double _smax, bool _rot_variant, dou
     weight_mod = _weight_mod;
 }
 
+Op_Slew::Op_Slew(const ProblemData &_pdata, const Eigen::VectorXd &_smax_vec, bool _rot_variant, double _weight_mod)
+    : Operator(_pdata) {
+    if (!_rot_variant) {
+        throw std::invalid_argument("Op_Slew vector smax is only supported with rot_variant=true");
+    }
+    name = "Slew";
+    smax_vec = _smax_vec;
+    smax = (smax_vec.size() > 0) ? smax_vec.maxCoeff() : 0.0;
+    rot_variant = _rot_variant;
+    weight_mod = _weight_mod;
+}
+
 void Op_Slew::init() {
     spdlog::trace("Op_Slew::init  N = {}", pdata->N);
 
@@ -22,6 +34,21 @@ void Op_Slew::init() {
     spec_norm = sqrt(spec_norm2);
 
     Ax_size = pdata->Naxis * (pdata->N - 1);
+
+    if (smax_vec.size() > 0) {
+        int N_slew = pdata->N - 1;
+        int full_size = pdata->Naxis * N_slew;
+        if (smax_vec.size() == N_slew && pdata->Naxis > 1) {
+            Eigen::VectorXd broadcast(full_size);
+            for (int i_ax = 0; i_ax < pdata->Naxis; i_ax++) {
+                broadcast.segment(i_ax * N_slew, N_slew) = smax_vec;
+            }
+            smax_vec = broadcast;
+        } else if (smax_vec.size() != full_size) {
+            throw std::invalid_argument(
+                "Op_Slew: smax_vec size must be (N-1) or Naxis*(N-1)");
+        }
+    }
 
     if (do_init_weights) {
         obj_weight = 1.0;
@@ -58,9 +85,11 @@ void Op_Slew::prox(Eigen::VectorXd &X) {
     X.array() *= spec_norm;
 
     if (rot_variant) {
+        bool use_vec = (smax_vec.size() == X.size());
         for (int i = 0; i < X.size(); i++) {
-            double lower_bound = (target - tol);
-            double upper_bound = (target + tol);
+            double tol_i = use_vec ? (1.0 - cushion) * smax_vec(i) : tol;
+            double lower_bound = target - tol_i;
+            double upper_bound = target + tol_i;
             X(i) = X(i) < lower_bound ? lower_bound : X(i);
             X(i) = X(i) > upper_bound ? upper_bound : X(i);
         }
@@ -99,6 +128,7 @@ void Op_Slew::check(Eigen::VectorXd &X) {
     X.array() *= spec_norm;
 
     if (rot_variant) {
+        bool use_vec = (smax_vec.size() == X.size());
         for (int i = 0; i < X.size(); i++) {
 
             bool should_check = isnan(pdata->set_vals(i));
@@ -108,8 +138,9 @@ void Op_Slew::check(Eigen::VectorXd &X) {
             if (i < X.size() - 1) {
                 should_check = should_check || isnan(pdata->set_vals(i + 1));
             }
-            double lower_bound = (target - tol0);
-            double upper_bound = (target + tol0);
+            double tol_i = use_vec ? smax_vec(i) : tol0;
+            double lower_bound = target - tol_i;
+            double upper_bound = target + tol_i;
 
             if (((X(i) < lower_bound) || (X(i) > upper_bound)) && should_check) {
                 is_feas = 0;

--- a/gropt/src/op_slew.hpp
+++ b/gropt/src/op_slew.hpp
@@ -20,9 +20,11 @@ class Op_Slew : public Operator
 {
     protected:
         double smax;
+        Eigen::VectorXd smax_vec;
 
     public:
         Op_Slew(const ProblemData &_pdata, double _smax, bool _rot_variant, double _weight_mod);
+        Op_Slew(const ProblemData &_pdata, const Eigen::VectorXd &_smax_vec, bool _rot_variant, double _weight_mod);
         virtual void init();
 
         virtual void forward(Eigen::VectorXd &X, Eigen::VectorXd &out);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gropt"
-version = "2.0.0rc12"
+version = "2.0.0rc13"
 requires-python = ">=3.10"
 dependencies = ["numpy"]
 


### PR DESCRIPTION
## Summary
- Adds a per-location slew-rate limit via a new vector overload of `Op_Slew` and a matching `GroptParams::add_smax_vec` method.
- Accepts `smax_vec` of length `N-1` (broadcast across all axes) or `Naxis*(N-1)` (per-axis limits). Wrong sizes throw.
- Vector limits are `rot_variant=true` only; constructing with `rot_variant=false` throws — a vector bound on the cross-axis slew magnitude is ill-defined under our current contract.
- Exposed through nanobind as `GroptParams.add_smax_vec(smax_vec, rot_variant=True, weight_mod=1.0)`. `.pyi` regenerated by stubgen.
- Bumps version to `2.0.0rc13`.

## Test plan
- [x] Build via `pixi run -e dev rebuild` — clean.
- [x] Smoke test: bad vector size raises `ValueError`.
- [x] Smoke test: `rot_variant=False` with vector raises `ValueError`.
- [x] Solve with a tightened window (`smax_vec[60:100] = 10`, else `50`) — solver converges, max slew is 8.7 inside the window and 35 outside, both inside their bounds.