### PR TITLE
Add per-location gradient amplitude constraint (v2.0.0rc14)

### DIFF
--- a/gropt/gropt_wrapper.pyi
+++ b/gropt/gropt_wrapper.pyi
@@ -6,7 +6,7 @@ import numpy
 from numpy.typing import NDArray
 
 
-__build_date__: str = 'May 17 2026 09:36:00'
+__build_date__: str = 'May 17 2026 17:59:53'
 
 def set_log_level(level: int) -> None:
     """
@@ -270,6 +270,23 @@ class GroptParams:
             Maximum allowed gradient magnitude [T/m].
         rot_variant : bool, optional
             If True, use rotationally invariant formulation.
+        weight_mod : float, optional
+            Weighting factor for this constraint.
+        """
+
+    def add_gmax_vec(self, gmax_vec: Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')], rot_variant: bool = True, weight_mod: float = 1.0) -> None:
+        """
+        Add a per-location gradient amplitude constraint.
+
+        Parameters
+        ----------
+        gmax_vec : np.ndarray
+            Gradient amplitude limit at each location [T/m]. Length N is broadcast
+            across all axes; length Naxis*N sets a per-axis limit. Only supported
+            with rot_variant=True.
+        rot_variant : bool, optional
+            Must be True. A vector limit on the gradient magnitude across axes is
+            not supported.
         weight_mod : float, optional
             Weighting factor for this constraint.
         """

--- a/gropt/gropt_wrapper/gropt_wrapper.cpp
+++ b/gropt/gropt_wrapper/gropt_wrapper.cpp
@@ -295,6 +295,24 @@ weight_mod : float, optional
     Weighting factor for this constraint.)doc"
         )
 
+        // add_gmax_vec
+        .def("add_gmax_vec", &Gropt::GroptParams::add_gmax_vec,
+            "gmax_vec"_a, "rot_variant"_a = true, "weight_mod"_a = 1.0,
+R"doc(Add a per-location gradient amplitude constraint.
+
+Parameters
+----------
+gmax_vec : np.ndarray
+    Gradient amplitude limit at each location [T/m]. Length N is broadcast
+    across all axes; length Naxis*N sets a per-axis limit. Only supported
+    with rot_variant=True.
+rot_variant : bool, optional
+    Must be True. A vector limit on the gradient magnitude across axes is
+    not supported.
+weight_mod : float, optional
+    Weighting factor for this constraint.)doc"
+        )
+
 
         // add_concomitant
         .def("add_concomitant", &Gropt::GroptParams::add_concomitant,

--- a/gropt/src/gropt_params.cpp
+++ b/gropt/src/gropt_params.cpp
@@ -339,6 +339,10 @@ void GroptParams::add_gmax(double gmax, bool rot_variant, double weight_mod) {
     all_op.push_back(std::make_unique<Op_Gradient>(pdata, gmax, rot_variant, weight_mod));
 }
 
+void GroptParams::add_gmax_vec(const Eigen::VectorXd &gmax_vec, bool rot_variant, double weight_mod) {
+    all_op.push_back(std::make_unique<Op_Gradient>(pdata, gmax_vec, rot_variant, weight_mod));
+}
+
 void GroptParams::add_smax(double smax, bool rot_variant, double weight_mod) {
     all_op.push_back(std::make_unique<Op_Slew>(pdata, smax, rot_variant, weight_mod));
 }

--- a/gropt/src/gropt_params.hpp
+++ b/gropt/src/gropt_params.hpp
@@ -72,6 +72,7 @@ class GroptParams {
     void set_ils_solver(std::string ils_method);
 
     void add_gmax(double gmax, bool rot_variant, double weight_mod);
+    void add_gmax_vec(const Eigen::VectorXd &gmax_vec, bool rot_variant, double weight_mod);
     void add_smax(double smax, bool rot_variant, double weight_mod);
     void add_smax_vec(const Eigen::VectorXd &smax_vec, bool rot_variant, double weight_mod);
     void add_concomitant(int start_idx, bool rot_variant, double weight_mod);

--- a/gropt/src/op_gradient.cpp
+++ b/gropt/src/op_gradient.cpp
@@ -12,6 +12,19 @@ Op_Gradient::Op_Gradient(const ProblemData &_pdata, double _gmax, bool _rot_vari
     weight_mod = _weight_mod;
 }
 
+Op_Gradient::Op_Gradient(const ProblemData &_pdata, const Eigen::VectorXd &_gmax_vec, bool _rot_variant,
+                         double _weight_mod)
+    : Operator(_pdata) {
+    if (!_rot_variant) {
+        throw std::invalid_argument("Op_Gradient vector gmax is only supported with rot_variant=true");
+    }
+    name = "Gradient";
+    gmax_vec = _gmax_vec;
+    gmax = (gmax_vec.size() > 0) ? gmax_vec.maxCoeff() : 0.0;
+    rot_variant = _rot_variant;
+    weight_mod = _weight_mod;
+}
+
 void Op_Gradient::init() {
     spdlog::trace("Op_Gradient::init  N = {}", pdata->N);
 
@@ -23,6 +36,20 @@ void Op_Gradient::init() {
     spec_norm = 1.0;
 
     Ax_size = pdata->Naxis * pdata->N;
+
+    if (gmax_vec.size() > 0) {
+        int full_size = pdata->Naxis * pdata->N;
+        if (gmax_vec.size() == pdata->N && pdata->Naxis > 1) {
+            Eigen::VectorXd broadcast(full_size);
+            for (int i_ax = 0; i_ax < pdata->Naxis; i_ax++) {
+                broadcast.segment(i_ax * pdata->N, pdata->N) = gmax_vec;
+            }
+            gmax_vec = broadcast;
+        } else if (gmax_vec.size() != full_size) {
+            throw std::invalid_argument(
+                "Op_Gradient: gmax_vec size must be N or Naxis*N");
+        }
+    }
 
     if (do_init_weights) {
         obj_weight = 1.0;
@@ -44,9 +71,11 @@ void Op_Gradient::prox(Eigen::VectorXd &X) {
     }
 
     if (rot_variant) {
+        bool use_vec = (gmax_vec.size() == X.size());
         for (int i = 0; i < X.size(); i++) {
-            double lower_bound = (target - tol);
-            double upper_bound = (target + tol);
+            double tol_i = use_vec ? (1.0 - cushion) * gmax_vec(i) : tol;
+            double lower_bound = target - tol_i;
+            double upper_bound = target + tol_i;
             X(i) = X(i) < lower_bound ? lower_bound : X(i);
             X(i) = X(i) > upper_bound ? upper_bound : X(i);
 
@@ -94,9 +123,11 @@ void Op_Gradient::check(Eigen::VectorXd &X) {
     }
 
     if (rot_variant) {
+        bool use_vec = (gmax_vec.size() == X.size());
         for (int i = 0; i < X.size(); i++) {
-            double lower_bound = (target - tol0);
-            double upper_bound = (target + tol0);
+            double tol_i = use_vec ? gmax_vec(i) : tol0;
+            double lower_bound = target - tol_i;
+            double upper_bound = target + tol_i;
 
             if ((X(i) < lower_bound) || (X(i) > upper_bound) && isnan(pdata->set_vals(i))) {
                 is_feas = 0;

--- a/gropt/src/op_gradient.hpp
+++ b/gropt/src/op_gradient.hpp
@@ -21,9 +21,11 @@ class Op_Gradient : public Operator
 {
     protected:
         double gmax;
+        Eigen::VectorXd gmax_vec;
 
     public:
         Op_Gradient(const ProblemData &_pdata, double _gmax, bool _rot_variant, double _weight_mod);
+        Op_Gradient(const ProblemData &_pdata, const Eigen::VectorXd &_gmax_vec, bool _rot_variant, double _weight_mod);
         virtual void init();
 
         virtual void forward(Eigen::VectorXd &X, Eigen::VectorXd &out);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gropt"
-version = "2.0.0rc13"
+version = "2.0.0rc14"
 requires-python = ">=3.10"
 dependencies = ["numpy"]
 


### PR DESCRIPTION
## Summary
- Adds a per-location gradient amplitude limit via a new vector overload of `Op_Gradient` and a matching `GroptParams::add_gmax_vec` method.
- Accepts `gmax_vec` of length `N` (broadcast across all axes) or `Naxis*N` (per-axis limits). Wrong sizes throw.
- Vector limits are `rot_variant=true` only; constructing with `rot_variant=false` throws.
- Exposed as `GroptParams.add_gmax_vec(gmax_vec, rot_variant=True, weight_mod=1.0)`. `.pyi` regenerated.
- Bumps version to `2.0.0rc14`. Mirrors the `add_smax_vec` API shipped in rc13.

## Test plan
- [x] Build via `pixi run -e dev rebuild` — clean.
- [x] Bad vector size raises `ValueError`.
- [x] `rot_variant=False` with vector raises `ValueError`.
- [x] Solve with a tightened window (`gmax_vec[60:100] = 0.01`, else `0.08`) — converges, max `|G|` is 0.0095 inside the window and 0.058 outside, both within their bounds.